### PR TITLE
feat: add Dakera to Memory Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Vector, graph, episodic, and hybrid memory architectures for persistent agent co
 - [**MemSkill**](https://github.com/ViktorAxelsen/MemSkill) - Learning and evolving memory skills for self-evolving agents. Meta-memory that determines what to extract, remember, and forget. by [@ViktorAxelsen](https://github.com/ViktorAxelsen) (462 stars)
 - [**TeleMem**](https://github.com/TeleAI-UAGI/telemem) - High-performance drop-in Mem0 replacement. 19% higher accuracy, 43% fewer tokens, and 2.1x speedup via narrative dynamic extraction. by [@TeleAI-UAGI](https://github.com/TeleAI-UAGI) (454 stars)
 - [**Awesome-Agent-Memory**](https://github.com/TeleAI-UAGI/Awesome-Agent-Memory) - Curated systems, benchmarks, and papers on memory for LLMs/MLLMs -- long-term context, retrieval, and reasoning. by [@TeleAI-UAGI](https://github.com/TeleAI-UAGI) (394 stars)
+- [**Dakera**](https://github.com/Dakera-AI/dakera-mcp) - Persistent, decay-weighted vector memory MCP server for AI agents. 83 MCP tools for store, recall, hybrid BM25+vector search, knowledge graphs, and cross-agent memory sharing. Built in Rust. by [@Dakera-AI](https://github.com/Dakera-AI) (0 stars)
 <!-- /AUTOGEN:memory -->
 
 ## Agent-to-Agent Protocols

--- a/data/projects.json
+++ b/data/projects.json
@@ -1246,7 +1246,7 @@
   {
     "name": "ChatLab",
     "repo": "ChatLab/ChatLab",
-    "description": "Rediscover your social memories with local, AI-powered analysis. 本地化的聊天记录分析工具，通过 AI Agent 回顾你的社交记忆。",
+    "description": "Rediscover your social memories with local, AI-powered analysis. \u672c\u5730\u5316\u7684\u804a\u5929\u8bb0\u5f55\u5206\u6790\u5de5\u5177\uff0c\u901a\u8fc7 AI Agent \u56de\u987e\u4f60\u7684\u793e\u4ea4\u8bb0\u5fc6\u3002",
     "category": "memory",
     "maintainer": "ChatLab",
     "tags": [
@@ -1345,5 +1345,19 @@
       "codex"
     ],
     "stars": 2742
+  },
+  {
+    "name": "Dakera",
+    "repo": "Dakera-AI/dakera-mcp",
+    "description": "Persistent, decay-weighted vector memory MCP server for AI agents. 83 MCP tools for store, recall, hybrid BM25+vector search, knowledge graphs, and cross-agent memory sharing. Built in Rust.",
+    "category": "memory",
+    "maintainer": "Dakera-AI",
+    "tags": [
+      "production-ready",
+      "mcp",
+      "knowledge-graph",
+      "open-source"
+    ],
+    "stars": 0
   }
 ]


### PR DESCRIPTION
## Add Dakera — Persistent Decay-Weighted Vector Memory for AI Agents

**Dakera** is a production-grade AI agent memory server built in Rust, with an MCP server providing 83 tools.

- **Repo:** https://github.com/Dakera-AI/dakera-mcp
- **MCP tools:** 83 across 15 categories
- **Language:** Rust

**What makes it unique:**
- Decay-weighted importance scoring — memories fade like human memory, most-relevant surfaces first
- Hybrid retrieval: BM25 full-text + ONNX vector embeddings
- Knowledge graph construction, entity extraction, cross-agent memory sharing
- Session-scoped memory isolation
- Self-hosted via Docker or `cargo install dakera-mcp`

**Changes:**
1. Added to `data/projects.json` with category `memory`
2. Added to README Memory Systems section (manually generated, consistent with AUTOGEN format)

Meets criteria: actively maintained (commits within last 6 months), open source, documented README, and novel in its Rust-native decay-weighted approach.