### PR TITLE
ci: migrate ubuntu-latest -> self-hosted runner

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   monitor:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/update-stars.yml
+++ b/.github/workflows/update-stars.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   update:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.CI_LABEL_LINUX_X64) }}
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Routes Linux CI jobs to the EvoMap self-hosted runner (evomap-shoot, Debian 12, 8 cores, 31G RAM).

Affected files in this repo:
  - .github/workflows/check-links.yml
  - .github/workflows/monitor.yml
  - .github/workflows/update-stars.yml

Skipped across the org where ubuntu-latest is load-bearing (glibc pin, cross-platform matrix, deliberately paid runner).

If CI fails on this runner due to missing tooling, install via setup-* actions or open an issue. Revert with `git revert` on this commit.

Auto-merge is enabled — will land when required checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Label-only runner change with no application or workflow logic edits; risk is mainly self-hosted runner availability and whether required tooling is present on that host.
> 
> **Overview**
> Moves three scheduled/maintenance workflows from GitHub-hosted **`ubuntu-latest`** to the EvoMap **self-hosted** runner via `runs-on: [self-hosted, Linux, X64]`.
> 
> Affected workflows: **Check Links** (`.github/workflows/check-links.yml`), **Weekly Monitor** (`monitor.yml`), and **Update Star Counts** (`update-stars.yml`). Triggers, Node 24 setup, scripts, and permissions are unchanged—only the execution environment changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ebbe4c46344d7a941ba7cb2700044f6dc7702e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->