### PR TITLE
Add Autohand Code to coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ AI agents that write, debug, and maintain code autonomously.
 - [**Open SWE**](https://github.com/langchain-ai/open-swe) - Open-source asynchronous coding agent by LangChain for software engineering tasks. by [@langchain-ai](https://github.com/langchain-ai) (10,073 stars)
 - [**Mini-SWE-Agent**](https://github.com/SWE-agent/mini-swe-agent) - The 100-line AI agent that solves GitHub issues. Radically simple but scores >74% on SWE-bench verified. by [@SWE-agent](https://github.com/SWE-agent) (5,507 stars)
 - [**Reflexion**](https://github.com/noahshinn/reflexion) - Language agents with verbal reinforcement learning. Agents that learn from mistakes through self-reflection. by [@noahshinn](https://github.com/noahshinn) (3,193 stars)
+- [**Autohand Code**](https://github.com/autohandai/code-cli) - Ultra-fast self-evolving coding agent that runs in your terminal. by [@autohandai](https://github.com/autohandai) (140 stars)
 <!-- /AUTOGEN:coding -->
 
 ## Prompt and Behaviour Optimization

--- a/data/projects.json
+++ b/data/projects.json
@@ -549,6 +549,19 @@
     "stars": 94795
   },
   {
+    "name": "Autohand Code",
+    "repo": "autohandai/code-cli",
+    "description": "Ultra-fast self-evolving coding agent that runs in your terminal.",
+    "category": "coding",
+    "maintainer": "autohandai",
+    "tags": [
+      "terminal",
+      "self-evolving",
+      "coding-agent"
+    ],
+    "stars": 140
+  },
+  {
     "name": "Aider",
     "repo": "Aider-AI/aider",
     "description": "AI pair programming in your terminal. Edit code with LLMs across 100+ languages with deep Git integration.",


### PR DESCRIPTION
## What does this PR do?

Adds Autohand Code to the Agent Coding and Software Engineering section.

I added the project to `data/projects.json` and regenerated `README.md` from the repository script so the generated list stays in sync.

## Checklist

- [x] Project added to `data/projects.json` with correct schema
- [x] `node scripts/generate-readme.js` was run and README.md is up to date
- [x] Project meets inclusion criteria (open source, active, documented, 50+ stars)
- [x] Category is correct
- [x] Description is concise (1-2 sentences)
- [x] No duplicate entries

## Category

- [x] Agent Coding and Software Engineering

## Validation

- `git diff --check`
- `node scripts/generate-readme.js`
- `node scripts/check-links.js` -> 114 ok, 0 failures, 0 warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only list maintenance with no runtime or security impact.
> 
> **Overview**
> Adds **Autohand Code** (`autohandai/code-cli`) to the **Agent Coding and Software Engineering** section as a new catalog entry.
> 
> The change introduces a `data/projects.json` record (category `coding`, tags `terminal`, `self-evolving`, `coding-agent`, 140 stars) and updates the autogenerated `README.md` coding list so it includes the project link and one-line description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3842097af40f56ce8401e67bf117b97194c260e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->