### PR TITLE
Add ClawBench to benchmarks and evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Projects connecting AI agents to physical devices, robotics, and real-world envi
 - [WebArena](https://github.com/web-arena-x/webarena) (ICLR'24) - Realistic web environment for autonomous agents.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) (NeurIPS'24) - Open-ended tasks in real computer environments.
 - [GAIA](https://huggingface.co/gaia-benchmark) (ICLR'23) - General AI assistant capabilities benchmark.
+- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) ([arXiv'26](https://arxiv.org/abs/2604.08523)) - Live-web evaluation with 283 everyday tasks, isolated execution, and replayable five-layer traces.
 - [EvoClaw](https://github.com/FSoft-AI4Code/EvoClaw) (arXiv'26) - Evaluating agents on continuous software evolution.
 - [LoCoMo](https://github.com/snap-research/locomo) (arXiv'25) - Long-context memory benchmark for agent memory systems.
 


### PR DESCRIPTION
## What does this PR do?

Adds ClawBench to the hand-maintained `Benchmarks and Evaluation` section, with links to the official repository and primary paper.

ClawBench evaluates browser agents on 283 everyday live-web tasks using isolated execution and replayable five-layer traces. This complements the existing WebArena and OSWorld entries.

## Validation

- `node scripts/generate-readme.js`
- `node scripts/check-links.js` (111 OK, 0 failures, 2 transient GitHub API warnings on existing entries)
- `git diff --check`

## Checklist

- [x] Description is concise
- [x] No duplicate entry
- [x] Research Paper

I am a ClawBench maintainer and am submitting this entry transparently for maintainer review.
This contribution was prepared with assistance from OpenAI Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no code or runtime impact.
> 
> **Overview**
> Adds **ClawBench** to the hand-maintained **Benchmarks and Evaluation** list in `README.md`, placed after GAIA and before EvoClaw.
> 
> The new bullet links to the [TIGER-AI-Lab/ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) repo and the [arXiv'26 paper](https://arxiv.org/abs/2604.08523), and summarizes it as live-web evaluation with 283 everyday tasks, isolated execution, and replayable five-layer traces—alongside existing web/desktop benchmarks like WebArena and OSWorld.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049e512d968df8ee03cdd8b1fa2d71d159f7e983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->