### PR TITLE
harden: sanitize child_process call in check-links.js...

### DIFF
--- a/scripts/check-links.js
+++ b/scripts/check-links.js
@@ -10,7 +10,7 @@
  * Requires: gh CLI authenticated
  */
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
@@ -18,8 +18,7 @@ const PROJECTS_PATH = path.join(__dirname, '..', 'data', 'projects.json');
 
 function checkRepo(repo) {
   try {
-    const cmd = `gh api repos/${repo} --jq '{archived: .archived, disabled: .disabled, full_name: .full_name}'`;
-    const result = JSON.parse(execSync(cmd, { encoding: 'utf-8', timeout: 15000 }));
+    const result = JSON.parse(execFileSync('gh', ['api', `repos/${repo}`, '--jq', '{archived: .archived, disabled: .disabled, full_name: .full_name}'], { encoding: 'utf-8', timeout: 15000 }));
 
     if (result.archived) return { status: 'archived', repo };
     if (result.disabled) return { status: 'disabled', repo };


### PR DESCRIPTION
## Summary
Harden input handling in `scripts/check-links.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `scripts/check-links.js:22` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `repo`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Changes
- `scripts/check-links.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
