### PR TITLE
Add LWC memory system

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Vector, graph, episodic, and hybrid memory architectures for persistent agent co
 - [**Awesome-Agent-Memory**](https://github.com/TeleAI-UAGI/Awesome-Agent-Memory) - Curated systems, benchmarks, and papers on memory for LLMs/MLLMs -- long-term context, retrieval, and reasoning. by [@TeleAI-UAGI](https://github.com/TeleAI-UAGI) (576 stars)
 - [**MemSkill**](https://github.com/ViktorAxelsen/MemSkill) - Learning and evolving memory skills for self-evolving agents. Meta-memory that determines what to extract, remember, and forget. by [@ViktorAxelsen](https://github.com/ViktorAxelsen) (560 stars)
 - [**TeleMem**](https://github.com/TeleAI-UAGI/telemem) - High-performance drop-in Mem0 replacement. 19% higher accuracy, 43% fewer tokens, and 2.1x speedup via narrative dynamic extraction. by [@TeleAI-UAGI](https://github.com/TeleAI-UAGI) (481 stars)
+- [**LWC**](https://github.com/JanYork/llm-wiki-cli) - Proactive, source-grounded project memory for coding agents with immutable sources, citations, provenance, SQLite full-text retrieval, and optional document and code graphs. by [@JanYork](https://github.com/JanYork) (31 stars)
 <!-- /AUTOGEN:memory -->
 
 ## Agent-to-Agent Protocols

--- a/data/projects.json
+++ b/data/projects.json
@@ -1374,6 +1374,19 @@
     "stars": 20108
   },
   {
+    "name": "LWC",
+    "repo": "JanYork/llm-wiki-cli",
+    "description": "Proactive, source-grounded project memory for coding agents with immutable sources, citations, provenance, SQLite full-text retrieval, and optional document and code graphs.",
+    "category": "memory",
+    "maintainer": "JanYork",
+    "tags": [
+      "mcp",
+      "open-source",
+      "lightweight"
+    ],
+    "stars": 31
+  },
+  {
     "name": "agent-device",
     "repo": "callstack/agent-device",
     "description": "CLI that lets AI agents drive real iOS and Android devices — taps, text input, screenshots, and app control for mobile automation",


### PR DESCRIPTION
## What does this PR do?

Adds [LWC](https://github.com/JanYork/llm-wiki-cli) to the generated Memory Systems catalog. LWC gives coding agents proactive, source-grounded project memory with immutable sources, citations, provenance, atomic changesets, SQLite/FTS5 retrieval, optional document and code graphs, lifecycle hooks, skills, and a bounded read-only MCP interface.

## Checklist

- [x] Project added to `data/projects.json` with the documented schema
- [x] `node scripts/generate-readme.js` was run and README.md is up to date
- [x] Project is open source, active, and documented
- [x] Category is correct
- [x] Description is concise
- [x] No duplicate entry exists

## Category

- [x] Memory Systems

## Minimum-traction exception

LWC currently has 31 stars, below the usual 50-star guideline. I am requesting the documented novel/unique exception because it combines a source-grounded, auditable canonical store with two independently verifiable graph projections and native lifecycle integration across nine coding-agent hosts. It is actively maintained (latest activity 2026-08-14), Apache-2.0 licensed, documented, tested, and distributed through npm as `@i-xor/lwc`.

## Verification

- `node scripts/generate-readme.js` — passes
- `node scripts/check-links.js` — 114 repository links checked successfully
- `git diff --check` — passes