### PR TITLE
Add ATM-Bench to Benchmarks and Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Projects connecting AI agents to physical devices, robotics, and real-world envi
 - [GAIA](https://huggingface.co/gaia-benchmark) (ICLR'23) - General AI assistant capabilities benchmark.
 - [EvoClaw](https://github.com/FSoft-AI4Code/EvoClaw) (arXiv'26) - Evaluating agents on continuous software evolution.
 - [LoCoMo](https://github.com/snap-research/locomo) (arXiv'25) - Long-context memory benchmark for agent memory systems.
+- [ATM-Bench](https://github.com/atmbench/atmbench.github.io) (arXiv'26) - First multimodal, multi-source benchmark for personalized referential memory QA over ~4 years of personal records (emails, images, videos).
 
 ## Community and Knowledge
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Projects connecting AI agents to physical devices, robotics, and real-world envi
 - [GAIA](https://huggingface.co/gaia-benchmark) (ICLR'23) - General AI assistant capabilities benchmark.
 - [EvoClaw](https://github.com/FSoft-AI4Code/EvoClaw) (arXiv'26) - Evaluating agents on continuous software evolution.
 - [LoCoMo](https://github.com/snap-research/locomo) (arXiv'25) - Long-context memory benchmark for agent memory systems.
-- [ATM-Bench](https://github.com/atmbench/atmbench.github.io) (arXiv'26) - First multimodal, multi-source benchmark for personalized referential memory QA over ~4 years of personal records (emails, images, videos).
+- [ATM-Bench](https://github.com/JingbiaoMei/ATM-Bench) (arXiv'26) - First multimodal, multi-source benchmark for personalized referential memory QA over ~4 years of personal records (emails, images, videos).
 
 ## Community and Knowledge
 


### PR DESCRIPTION
Add ATM-Bench to the Benchmarks and Evaluation list.

ATM-Bench (According to Me: Long-Term Personalized Referential Memory QA) is the first multimodal, multi-source benchmark for personalized referential memory QA over ~4 years of privacy-preserving personal records (emails, images, videos); queries require resolving personal references, multi-evidence reasoning, and handling conflicting evidence.

- arXiv: https://arxiv.org/abs/2603.01990
- Project: https://atmbench.github.io/
- Code: https://github.com/JingbiaoMei/ATM-Bench
