### PR TITLE
chore: add curation quality gates and restore all entries

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-submission.yml
+++ b/.github/ISSUE_TEMPLATE/project-submission.yml
@@ -27,6 +27,7 @@ body:
         - Agent-to-Agent Protocols
         - Agent Development Platforms
         - Agent Coding and Software Engineering
+        - Multi-Agent Frameworks
         - Prompt and Behaviour Optimization
         - Agent Safety and Guardrails
         - Embodied AI

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,11 @@
 
 - [ ] Project added to `data/projects.json` with correct schema
 - [ ] `node scripts/generate-readme.js` was run and README.md is up to date
-- [ ] Project meets inclusion criteria (open source, active, documented, 50+ stars)
-- [ ] Category is correct
-- [ ] Description is concise (1-2 sentences)
+- [ ] `node scripts/validate.js` passes
+- [ ] Project meets inclusion criteria (open source, active, documented, 50+ stars or a documented novelty exception)
+- [ ] Category and cross-list scope are correct; any duplicate listing is justified
+- [ ] Description is concise, objective, starts with a capital letter, and ends with punctuation
+- [ ] Links, paper, license, and factual claims were checked against primary sources
 - [ ] No duplicate entries
 
 ## Category
@@ -21,6 +23,7 @@
 - [ ] Agent-to-Agent Protocols
 - [ ] Agent Development Platforms
 - [ ] Agent Coding and Software Engineering
+- [ ] Multi-Agent Frameworks
 - [ ] Prompt and Behaviour Optimization
 - [ ] Agent Safety and Guardrails
 - [ ] Embodied AI

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,30 @@
+name: Validate curated data
+
+on:
+  pull_request:
+    paths:
+      - 'README.md'
+      - 'data/**'
+      - 'scripts/generate-readme.js'
+      - 'scripts/validate.js'
+      - 'CONTRIBUTING.md'
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+      - name: Validate curated data and generated README
+        run: node scripts/validate.js
+      - name: Confirm generated README is clean
+        run: |
+          node scripts/generate-readme.js
+          git diff --exit-code -- README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,19 @@ Projects should meet the following criteria:
 1. Fork this repository
 2. Add the project to `data/projects.json` following the schema below
 3. Run `node scripts/generate-readme.js` to regenerate the README
-4. Submit a pull request with a brief description of the project
+4. Run `node scripts/validate.js` and `node scripts/check-links.js`
+5. Submit a pull request with a brief description of the project and why it belongs in this list
 
-## Project JSON Schema
+## Scope and Cross-List Entries
+
+This list focuses on self-evolution, memory, agent infrastructure, coding, optimization, safety, and embodied agents. Multi-agent systems whose primary contribution is swarm coordination or team orchestration should normally be submitted to [awesome-agent-swarm](https://github.com/EvoMap/awesome-agent-swarm).
+
+A project may appear in both lists only when it makes a substantial, independently relevant contribution to both scopes. Explain that contribution in the pull request; popularity alone is not a reason for duplicate inclusion.
+
+## Curation Standard
+
+Meeting the minimum checks does not guarantee inclusion. Maintainers also review technical relevance, evidence for claims, maintenance quality, licensing, documentation, distinctiveness, and whether the description is objective. Discovery scripts produce candidates for human review and never imply endorsement.
+
 
 Each entry in `data/projects.json` should follow this format:
 
@@ -32,7 +42,7 @@ Each entry in `data/projects.json` should follow this format:
   "name": "Project Name",
   "repo": "owner/repo",
   "description": "One-line description of the project",
-  "category": "evolution|memory|protocols|platforms|coding|prompt-optimization|safety|embodied|community",
+  "category": "evolution|memory|protocols|platforms|coding|multi-agent|prompt-optimization|safety|embodied|community",
   "maintainer": "github-username",
   "tags": ["tag1", "tag2", "tag3"],
   "stars": 0,
@@ -49,6 +59,7 @@ Each entry in `data/projects.json` should follow this format:
 | `protocols` | A2A, MCP, and inter-agent communication protocols |
 | `platforms` | Agent development and deployment platforms |
 | `coding` | Agent coding and software engineering tools |
+| `multi-agent` | Multi-agent frameworks relevant to evolution and shared agent infrastructure |
 | `prompt-optimization` | Prompt and behaviour optimization frameworks |
 | `safety` | Agent safety, guardrails, and alignment |
 | `embodied` | Embodied AI, robotics, and device control |

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Agent-to-Agent Protocols](#agent-to-agent-protocols)
 - [Agent Development Platforms](#agent-development-platforms)
 - [Agent Coding and Software Engineering](#agent-coding-and-software-engineering)
+- [Multi-Agent Frameworks](#multi-agent-frameworks)
 - [Prompt and Behaviour Optimization](#prompt-and-behaviour-optimization)
 - [Agent Safety and Guardrails](#agent-safety-and-guardrails)
 - [Embodied AI](#embodied-ai)
@@ -40,19 +41,19 @@ graph LR
 Projects focused on enabling AI agents to evolve, learn, and improve autonomously.
 
 <!-- AUTOGEN:evolution -->
-- [**Eliza**](https://github.com/elizaOS/eliza) - Autonomous agents for everyone. A framework for creating and deploying AI agents that evolve over time. by [@elizaOS](https://github.com/elizaOS) (19,168 stars)
-- [**Agent Zero**](https://github.com/agent0ai/agent-zero) - General-purpose AI agent framework that learns and evolves through interaction. by [@agent0ai](https://github.com/agent0ai) (18,969 stars)
-- [**SuperAGI**](https://github.com/TransformerOptimus/SuperAGI) - A dev-first open source autonomous AI agent framework. Build, manage and run self-improving autonomous agents. by [@TransformerOptimus](https://github.com/TransformerOptimus) (17,660 stars)
-- [**evolver**](https://github.com/EvoMap/evolver) - The GEP-powered self-evolution engine for AI agents. Genome Evolution Protocol enables agents to evolve autonomously via mutation and selection. by [@EvoMap](https://github.com/EvoMap) (9,005 stars)
-- [**OpenEvolve**](https://github.com/algorithmicsuperintelligence/openevolve) - Open-source evolutionary coding agent inspired by AlphaEvolve. Evolves code solutions through LLM-driven mutation and selection. by [@algorithmicsuperintelligence](https://github.com/algorithmicsuperintelligence) (7,269 stars)
-- [**Agents (aiwaves)**](https://github.com/aiwaves-cn/agents) - An open-source framework for data-centric, self-evolving autonomous language agents. by [@aiwaves-cn](https://github.com/aiwaves-cn) (5,957 stars)
-- [**EvoAgentX**](https://github.com/EvoAgentX/EvoAgentX) - Automated framework for evolving agentic workflows. Optimizes agent prompts, tools, and pipelines via evolutionary algorithms. by [@EvoAgentX](https://github.com/EvoAgentX) (3,253 stars)
-- [**HyperAgents**](https://github.com/facebookresearch/HyperAgents) - Self-referential self-improving agents by Meta. DGM-Hyperagents add an optimization layer so agents edit their own improvement process. by [@facebookresearch](https://github.com/facebookresearch) (2,696 stars)
-- [**SIA**](https://github.com/hexo-ai/sia) - Self-improving AI framework that autonomously optimizes the performance of any AI system through iterative evaluation and refinement. by [@hexo-ai](https://github.com/hexo-ai) (2,122 stars)
-- [**Agent0**](https://github.com/aiming-lab/Agent0) - Self-evolving agent framework from UNC/Salesforce/Stanford. Improves without human-curated datasets via curriculum and executor agent competition. by [@aiming-lab](https://github.com/aiming-lab) (1,254 stars)
-- [**Ouroboros**](https://github.com/razzant/ouroboros) - Self-creating AI agent that writes its own code and evolves autonomously. Completed 30+ evolution cycles in first 24 hours with zero human intervention. by [@razzant](https://github.com/razzant) (1,228 stars)
-- [**A-Evolve**](https://github.com/A-EVO-Lab/a-evolve) - The PyTorch for Agentic AI. Open-source infrastructure that evolves any agent across any domain with zero human intervention. #1 on MCP-Atlas (79.4%). by [@A-EVO-Lab](https://github.com/A-EVO-Lab) (752 stars)
-- [**SEAgent**](https://github.com/SunzeY/SEAgent) - Self-Evolving Computer Use Agent with Autonomous Learning from Experience. by [@SunzeY](https://github.com/SunzeY) (263 stars)
+- [**Eliza**](https://github.com/elizaOS/eliza#readme) - Autonomous agents for everyone. A framework for creating and deploying AI agents that evolve over time. by [@elizaOS](https://github.com/elizaOS) (19,168 stars)
+- [**Agent Zero**](https://github.com/agent0ai/agent-zero#readme) - General-purpose AI agent framework that learns and evolves through interaction. by [@agent0ai](https://github.com/agent0ai) (18,969 stars)
+- [**SuperAGI**](https://github.com/TransformerOptimus/SuperAGI#readme) - A dev-first open source autonomous AI agent framework. Build, manage and run self-improving autonomous agents. by [@TransformerOptimus](https://github.com/TransformerOptimus) (17,660 stars)
+- [**evolver**](https://github.com/EvoMap/evolver#readme) - The GEP-powered self-evolution engine for AI agents. Genome Evolution Protocol enables agents to evolve autonomously via mutation and selection. by [@EvoMap](https://github.com/EvoMap) (9,005 stars)
+- [**OpenEvolve**](https://github.com/algorithmicsuperintelligence/openevolve#readme) - Open-source evolutionary coding agent inspired by AlphaEvolve. Evolves code solutions through LLM-driven mutation and selection. by [@algorithmicsuperintelligence](https://github.com/algorithmicsuperintelligence) (7,269 stars)
+- [**Agents (aiwaves)**](https://github.com/aiwaves-cn/agents#readme) - An open-source framework for data-centric, self-evolving autonomous language agents. by [@aiwaves-cn](https://github.com/aiwaves-cn) (5,957 stars)
+- [**EvoAgentX**](https://github.com/ANative-Lab/EvoAgentX#readme) - Automated framework for evolving agentic workflows. Optimizes agent prompts, tools, and pipelines via evolutionary algorithms. by [@ANative-Lab](https://github.com/ANative-Lab) (3,253 stars)
+- [**HyperAgents**](https://github.com/facebookresearch/HyperAgents#readme) - Self-referential self-improving agents by Meta. DGM-Hyperagents add an optimization layer so agents edit their own improvement process. by [@facebookresearch](https://github.com/facebookresearch) (2,696 stars)
+- [**SIA**](https://github.com/hexo-ai/sia#readme) - Self-improving AI framework that autonomously optimizes the performance of any AI system through iterative evaluation and refinement. by [@hexo-ai](https://github.com/hexo-ai) (2,122 stars)
+- [**Agent0**](https://github.com/aiming-lab/Agent0#readme) - Self-evolving agent framework from UNC/Salesforce/Stanford. Improves without human-curated datasets via curriculum and executor agent competition. by [@aiming-lab](https://github.com/aiming-lab) (1,254 stars)
+- [**Ouroboros**](https://github.com/razzant/ouroboros#readme) - Self-creating AI agent that writes its own code and evolves autonomously. Completed 30+ evolution cycles in first 24 hours with zero human intervention. by [@razzant](https://github.com/razzant) (1,228 stars)
+- [**A-Evolve**](https://github.com/A-EVO-Lab/a-evolve#readme) - The PyTorch for Agentic AI. Open-source infrastructure that evolves any agent across any domain with zero human intervention. #1 on MCP-Atlas (79.4%). by [@A-EVO-Lab](https://github.com/A-EVO-Lab) (752 stars)
+- [**SEAgent**](https://github.com/SunzeY/SEAgent#readme) - Self-Evolving Computer Use Agent with Autonomous Learning from Experience. by [@SunzeY](https://github.com/SunzeY) (263 stars)
 <!-- /AUTOGEN:evolution -->
 
 ## Memory Systems
@@ -60,28 +61,28 @@ Projects focused on enabling AI agents to evolve, learn, and improve autonomousl
 Vector, graph, episodic, and hybrid memory architectures for persistent agent cognition.
 
 <!-- AUTOGEN:memory -->
-- [**Mem0**](https://github.com/mem0ai/mem0) - Production-ready AI agent memory with scalable long-term memory. 26% improvement over baseline on LOCOMO benchmark with 91% latency reduction. by [@mem0ai](https://github.com/mem0ai) (64,055 stars)
-- [**Cognee**](https://github.com/topoteretes/cognee) - Knowledge engine for AI agent memory. Build and query knowledge graphs from unstructured data in 6 lines of code. by [@topoteretes](https://github.com/topoteretes) (30,268 stars)
-- [**agentmemory**](https://github.com/rohitg00/agentmemory) - Persistent, benchmark-tuned memory for coding agents (Claude Code, Cursor, Copilot CLI, Codex, and any MCP client). Remembers context across sessions so you stop re-explaining. by [@rohitg00](https://github.com/rohitg00) (27,433 stars)
-- [**TencentDB Agent Memory**](https://github.com/TencentCloud/TencentDB-Agent-Memory) - Fully local long-term memory for AI agents via a four-tier progressive storage architecture, from Tencent Cloud. by [@TencentCloud](https://github.com/TencentCloud) (24,503 stars)
-- [**Letta**](https://github.com/letta-ai/letta) - Platform for building stateful agents with advanced self-editing memory. Formerly MemGPT. by [@letta-ai](https://github.com/letta-ai) (24,442 stars)
-- [**Memvid**](https://github.com/memvid/memvid) - Single-file memory layer for AI Agents in Rust. +35% SOTA on LoCoMo with ultra-low latency (0.025ms P50). by [@memvid](https://github.com/memvid) (16,448 stars)
-- [**memU**](https://github.com/NevaMind-AI/memU) - Memory system for 24/7 proactive agents. Persistent memory across sessions and platforms. by [@NevaMind-AI](https://github.com/NevaMind-AI) (14,347 stars)
-- [**EverMemOS**](https://github.com/EverMind-AI/EverOS) - Long-term memory for 24/7 AI agents across LLMs and platforms. by [@EverMind-AI](https://github.com/EverMind-AI) (12,430 stars)
-- [**holaOS**](https://github.com/holaboss-ai/holaOS) - Agent environment for long-horizon work, continuity, and self-evolution. by [@holaboss-ai](https://github.com/holaboss-ai) (10,871 stars)
-- [**ChatLab**](https://github.com/ChatLab/ChatLab) - Rediscover your social memories with local, AI-powered analysis. 本地化的聊天记录分析工具，通过 AI Agent 回顾你的社交记忆。. by [@ChatLab](https://github.com/ChatLab) (7,246 stars)
-- [**honcho**](https://github.com/plastic-labs/honcho) - Memory library for building stateful agents with user context management. by [@plastic-labs](https://github.com/plastic-labs) (6,842 stars)
-- [**memgraph**](https://github.com/memgraph/memgraph) - High-performance open-source in-memory graph database for GraphRAG, AI memory, agentic AI, and real-time graph analytics. Cypher-compatible, built in C++. by [@memgraph](https://github.com/memgraph) (4,361 stars)
-- [**Acontext**](https://github.com/memodb-io/Acontext) - Open-source skill memory layer for AI agents. Automatically captures learnings from agent runs and stores them as reusable skill files. by [@memodb-io](https://github.com/memodb-io) (3,677 stars)
-- [**ReMe**](https://github.com/agentscope-ai/ReMe) - Memory management kit for agents. File-based and vector-based memory systems. SOTA on LoCoMo and HaluMem benchmarks. by [@agentscope-ai](https://github.com/agentscope-ai) (3,352 stars)
-- [**MemMachine**](https://github.com/MemMachine/MemMachine) - Universal memory layer for AI agents. Episodic (graph-based), profile (SQL), and working memory with scalable storage and retrieval. by [@MemMachine](https://github.com/MemMachine) (3,201 stars)
-- [**datachain**](https://github.com/datachain-ai/datachain) - Operational data context layer for AI agents providing typed and versioned datasets over multimodal content. by [@datachain-ai](https://github.com/datachain-ai) (2,811 stars)
-- [**nocturne_memory**](https://github.com/Dataojitori/nocturne_memory) - Lightweight, rollbackable Long-Term Memory Server for MCP Agents with graph-like structured memory. by [@Dataojitori](https://github.com/Dataojitori) (1,331 stars)
-- [**Mem9**](https://github.com/mem9-ai/mem9) - Unlimited persistent memory layer for AI agents. Cloud-synced memory across sessions and tools. by [@mem9-ai](https://github.com/mem9-ai) (1,200 stars)
-- [**Awesome-AI-Memory**](https://github.com/IAAR-Shanghai/Awesome-AI-Memory) - Curated knowledge base on AI memory for LLMs and agents, covering long-term memory, reasoning, retrieval, and system design. by [@IAAR-Shanghai](https://github.com/IAAR-Shanghai) (1,179 stars)
-- [**Awesome-Agent-Memory**](https://github.com/TeleAI-UAGI/Awesome-Agent-Memory) - Curated systems, benchmarks, and papers on memory for LLMs/MLLMs -- long-term context, retrieval, and reasoning. by [@TeleAI-UAGI](https://github.com/TeleAI-UAGI) (607 stars)
-- [**MemSkill**](https://github.com/ViktorAxelsen/MemSkill) - Learning and evolving memory skills for self-evolving agents. Meta-memory that determines what to extract, remember, and forget. by [@ViktorAxelsen](https://github.com/ViktorAxelsen) (565 stars)
-- [**TeleMem**](https://github.com/TeleAI-UAGI/telemem) - High-performance drop-in Mem0 replacement. 19% higher accuracy, 43% fewer tokens, and 2.1x speedup via narrative dynamic extraction. by [@TeleAI-UAGI](https://github.com/TeleAI-UAGI) (486 stars)
+- [**Mem0**](https://github.com/mem0ai/mem0#readme) - Production-ready AI agent memory with scalable long-term memory. 26% improvement over baseline on LOCOMO benchmark with 91% latency reduction. by [@mem0ai](https://github.com/mem0ai) (64,055 stars)
+- [**Cognee**](https://github.com/topoteretes/cognee#readme) - Knowledge engine for AI agent memory. Build and query knowledge graphs from unstructured data in 6 lines of code. by [@topoteretes](https://github.com/topoteretes) (30,268 stars)
+- [**agentmemory**](https://github.com/rohitg00/agentmemory#readme) - Persistent, benchmark-tuned memory for coding agents (Claude Code, Cursor, Copilot CLI, Codex, and any MCP client). Remembers context across sessions so you stop re-explaining. by [@rohitg00](https://github.com/rohitg00) (27,433 stars)
+- [**TencentDB Agent Memory**](https://github.com/TencentCloud/TencentDB-Agent-Memory#readme) - Fully local long-term memory for AI agents via a four-tier progressive storage architecture, from Tencent Cloud. by [@TencentCloud](https://github.com/TencentCloud) (24,503 stars)
+- [**Letta**](https://github.com/letta-ai/letta#readme) - Platform for building stateful agents with advanced self-editing memory. Formerly MemGPT. by [@letta-ai](https://github.com/letta-ai) (24,442 stars)
+- [**Memvid**](https://github.com/memvid/memvid#readme) - Single-file memory layer for AI Agents in Rust. +35% SOTA on LoCoMo with ultra-low latency (0.025ms P50). by [@memvid](https://github.com/memvid) (16,448 stars)
+- [**memU**](https://github.com/NevaMind-AI/memU#readme) - Memory system for 24/7 proactive agents. Persistent memory across sessions and platforms. by [@NevaMind-AI](https://github.com/NevaMind-AI) (14,347 stars)
+- [**EverMemOS**](https://github.com/EverMind-AI/EverOS#readme) - Long-term memory for 24/7 AI agents across LLMs and platforms. by [@EverMind-AI](https://github.com/EverMind-AI) (12,430 stars)
+- [**holaOS**](https://github.com/holaboss-ai/holaOS#readme) - Agent environment for long-horizon work, continuity, and self-evolution. by [@holaboss-ai](https://github.com/holaboss-ai) (10,871 stars)
+- [**ChatLab**](https://github.com/ChatLab/ChatLab#readme) - Rediscover your social memories with local, AI-powered analysis. 本地化的聊天记录分析工具，通过 AI Agent 回顾你的社交记忆。. by [@ChatLab](https://github.com/ChatLab) (7,246 stars)
+- [**honcho**](https://github.com/plastic-labs/honcho#readme) - Memory library for building stateful agents with user context management. by [@plastic-labs](https://github.com/plastic-labs) (6,842 stars)
+- [**memgraph**](https://github.com/memgraph/memgraph#readme) - High-performance open-source in-memory graph database for GraphRAG, AI memory, agentic AI, and real-time graph analytics. Cypher-compatible, built in C++. by [@memgraph](https://github.com/memgraph) (4,361 stars)
+- [**Acontext**](https://github.com/memodb-io/Acontext#readme) - Open-source skill memory layer for AI agents. Automatically captures learnings from agent runs and stores them as reusable skill files. by [@memodb-io](https://github.com/memodb-io) (3,677 stars)
+- [**ReMe**](https://github.com/agentscope-ai/ReMe#readme) - Memory management kit for agents. File-based and vector-based memory systems. SOTA on LoCoMo and HaluMem benchmarks. by [@agentscope-ai](https://github.com/agentscope-ai) (3,352 stars)
+- [**MemMachine**](https://github.com/MemMachine/MemMachine#readme) - Universal memory layer for AI agents. Episodic (graph-based), profile (SQL), and working memory with scalable storage and retrieval. by [@MemMachine](https://github.com/MemMachine) (3,201 stars)
+- [**datachain**](https://github.com/datachain-ai/datachain#readme) - Operational data context layer for AI agents providing typed and versioned datasets over multimodal content. by [@datachain-ai](https://github.com/datachain-ai) (2,811 stars)
+- [**nocturne_memory**](https://github.com/Dataojitori/nocturne_memory#readme) - Lightweight, rollbackable Long-Term Memory Server for MCP Agents with graph-like structured memory. by [@Dataojitori](https://github.com/Dataojitori) (1,331 stars)
+- [**Mem9**](https://github.com/mem9-ai/mem9#readme) - Unlimited persistent memory layer for AI agents. Cloud-synced memory across sessions and tools. by [@mem9-ai](https://github.com/mem9-ai) (1,200 stars)
+- [**Awesome-AI-Memory**](https://github.com/IAAR-Shanghai/Awesome-AI-Memory#readme) - Curated knowledge base on AI memory for LLMs and agents, covering long-term memory, reasoning, retrieval, and system design. by [@IAAR-Shanghai](https://github.com/IAAR-Shanghai) (1,179 stars)
+- [**Awesome-Agent-Memory**](https://github.com/TeleAI-UAGI/Awesome-Agent-Memory#readme) - Curated systems, benchmarks, and papers on memory for LLMs/MLLMs -- long-term context, retrieval, and reasoning. by [@TeleAI-UAGI](https://github.com/TeleAI-UAGI) (607 stars)
+- [**MemSkill**](https://github.com/ViktorAxelsen/MemSkill#readme) - Learning and evolving memory skills for self-evolving agents. Meta-memory that determines what to extract, remember, and forget. by [@ViktorAxelsen](https://github.com/ViktorAxelsen) (565 stars)
+- [**TeleMem**](https://github.com/TeleAI-UAGI/telemem#readme) - High-performance drop-in Mem0 replacement. 19% higher accuracy, 43% fewer tokens, and 2.1x speedup via narrative dynamic extraction. by [@TeleAI-UAGI](https://github.com/TeleAI-UAGI) (486 stars)
 <!-- /AUTOGEN:memory -->
 
 ## Agent-to-Agent Protocols
@@ -89,13 +90,13 @@ Vector, graph, episodic, and hybrid memory architectures for persistent agent co
 Standards and protocols for inter-agent communication and interoperability.
 
 <!-- AUTOGEN:protocols -->
-- [**Google A2A**](https://github.com/a2aproject/A2A) - Google's open Agent-to-Agent protocol. Enables agent discovery, secure collaboration, and long-running tasks while preserving agent opacity. by [@a2aproject](https://github.com/a2aproject) (25,496 stars)
-- [**mcp-use**](https://github.com/mcp-use/mcp-use) - The fullstack MCP framework to develop MCP Apps for ChatGPT/Claude and MCP Servers for AI Agents. by [@mcp-use](https://github.com/mcp-use) (10,526 stars)
-- [**openagent**](https://github.com/the-open-agent/openagent) - Enterprise AI platform with MCP and A2A protocol management, knowledge base, and admin interface. by [@the-open-agent](https://github.com/the-open-agent) (5,567 stars)
-- [**ViteMCP**](https://github.com/punkpeye/fastmcp) - A TypeScript framework for building MCP servers. by [@punkpeye](https://github.com/punkpeye) (3,254 stars)
-- [**arcade-mcp**](https://github.com/ArcadeAI/arcade-mcp) - MCP server framework and tool-development library for building custom agent capabilities and authenticated tool calls. by [@ArcadeAI](https://github.com/ArcadeAI) (1,010 stars)
-- [**A2A x402**](https://github.com/google-agentic-commerce/a2a-x402) - A2A protocol extension adding x402 on-chain payments, letting agents monetize services over Agent-to-Agent calls. by [@google-agentic-commerce](https://github.com/google-agentic-commerce) (553 stars)
-- [**GEP MCP Server**](https://github.com/EvoMap/gep-mcp-server) - MCP Server for Genome Evolution Protocol. Exposes evolution tools to Claude Desktop, Cursor, and any MCP client. by [@EvoMap](https://github.com/EvoMap) (6 stars)
+- [**Google A2A**](https://github.com/a2aproject/A2A#readme) - Google's open Agent-to-Agent protocol. Enables agent discovery, secure collaboration, and long-running tasks while preserving agent opacity. by [@a2aproject](https://github.com/a2aproject) (25,496 stars)
+- [**mcp-use**](https://github.com/mcp-use/mcp-use#readme) - The fullstack MCP framework to develop MCP Apps for ChatGPT/Claude and MCP Servers for AI Agents. by [@mcp-use](https://github.com/mcp-use) (10,526 stars)
+- [**openagent**](https://github.com/the-open-agent/openagent#readme) - Enterprise AI platform with MCP and A2A protocol management, knowledge base, and admin interface. by [@the-open-agent](https://github.com/the-open-agent) (5,567 stars)
+- [**ViteMCP**](https://github.com/punkpeye/fastmcp#readme) - A TypeScript framework for building MCP servers. by [@punkpeye](https://github.com/punkpeye) (3,254 stars)
+- [**arcade-mcp**](https://github.com/ArcadeAI/arcade-mcp#readme) - MCP server framework and tool-development library for building custom agent capabilities and authenticated tool calls. by [@ArcadeAI](https://github.com/ArcadeAI) (1,010 stars)
+- [**A2A x402**](https://github.com/google-agentic-commerce/a2a-x402#readme) - A2A protocol extension adding x402 on-chain payments, letting agents monetize services over Agent-to-Agent calls. by [@google-agentic-commerce](https://github.com/google-agentic-commerce) (553 stars)
+- [**GEP MCP Server**](https://github.com/EvoMap/gep-mcp-server#readme) - MCP Server for Genome Evolution Protocol. Exposes evolution tools to Claude Desktop, Cursor, and any MCP client. by [@EvoMap](https://github.com/EvoMap) (6 stars)
 <!-- /AUTOGEN:protocols -->
 
 ## Agent Development Platforms
@@ -103,26 +104,26 @@ Standards and protocols for inter-agent communication and interoperability.
 Platforms and tools for building, deploying, and managing AI agents.
 
 <!-- AUTOGEN:platforms -->
-- [**dify**](https://github.com/langgenius/dify) - Production-ready platform for building agentic AI workflows with visual orchestration. by [@langgenius](https://github.com/langgenius) (153,529 stars)
-- [**LangChain**](https://github.com/langchain-ai/langchain) - Full-stack agent engineering platform with composable chains, tools, and memory integration. by [@langchain-ai](https://github.com/langchain-ai) (145,010 stars)
-- [**OpenHands**](https://github.com/OpenHands/OpenHands) - Open platform for AI software developers as generalist agents. Autonomous coding, debugging, and deployment. by [@OpenHands](https://github.com/OpenHands) (85,122 stars)
-- [**CowAgent**](https://github.com/zhayujie/CowAgent) - Super AI assistant based on LLMs with autonomous thinking, task planning, skill creation, and long-term memory. by [@zhayujie](https://github.com/zhayujie) (46,678 stars)
-- [**agno**](https://github.com/agno-agi/agno) - Production-ready agent framework that turns agents into deployable services with multi-framework support. by [@agno-agi](https://github.com/agno-agi) (41,928 stars)
-- [**langgraph**](https://github.com/langchain-ai/langgraph) - Build resilient language agents as stateful graphs with persistence and streaming. by [@langchain-ai](https://github.com/langchain-ai) (40,466 stars)
-- [**CoPaw**](https://github.com/agentscope-ai/QwenPaw) - Co Personal Agent Workstation built on AgentScope. Desktop agent platform with multi-agent collaboration and tool integration. by [@agentscope-ai](https://github.com/agentscope-ai) (34,476 stars)
-- [**mastra**](https://github.com/mastra-ai/mastra) - TypeScript framework for building AI-powered applications with agent workflows and RAG. by [@mastra-ai](https://github.com/mastra-ai) (27,477 stars)
-- [**AgenticSeek**](https://github.com/Fosowl/agenticSeek) - Fully local autonomous agent with browsing, coding, and multi-agent capabilities. No API keys required. by [@Fosowl](https://github.com/Fosowl) (27,017 stars)
-- [**haystack**](https://github.com/deepset-ai/haystack) - Open-source AI orchestration framework for building context-engineered production applications. by [@deepset-ai](https://github.com/deepset-ai) (26,318 stars)
-- [**Coze Studio**](https://github.com/coze-dev/coze-studio) - AI agent development platform with visual tools for creating, debugging, and deploying agents. by [@coze-dev](https://github.com/coze-dev) (21,503 stars)
-- [**Google ADK**](https://github.com/google/adk-python) - Open-source Python toolkit by Google for building, evaluating, and deploying sophisticated AI agents. by [@google](https://github.com/google) (21,290 stars)
-- [**PydanticAI**](https://github.com/pydantic/pydantic-ai) - Type-safe AI agent framework built on Pydantic with structured outputs and dependency injection. by [@pydantic](https://github.com/pydantic) (19,502 stars)
-- [**Parlant**](https://github.com/emcie-co/parlant) - The conversational control layer for customer-facing AI agents. A context-engineering framework for controlling interactions. by [@emcie-co](https://github.com/emcie-co) (18,269 stars)
-- [**OpenFang**](https://github.com/RightNow-AI/openfang) - Open-source Agent Operating System for deploying and managing AI agents. by [@RightNow-AI](https://github.com/RightNow-AI) (18,136 stars)
-- [**agents**](https://github.com/livekit/agents) - Framework for building realtime voice AI agents with speech-to-speech pipelines. by [@livekit](https://github.com/livekit) (13,166 stars)
-- [**ten-framework**](https://github.com/TEN-framework/ten-framework) - Open-source framework for building conversational voice AI agents. by [@TEN-framework](https://github.com/TEN-framework) (11,081 stars)
-- [**Agent-Squad**](https://github.com/2FastLabs/agent-squad) - Flexible framework for managing multiple AI agents and handling complex conversations. by [@2FastLabs](https://github.com/2FastLabs) (7,747 stars)
-- [**PySpur**](https://github.com/PySpur-Dev/pyspur) - Visual playground for agentic workflows with rapid iteration on multi-agent pipelines. by [@PySpur-Dev](https://github.com/PySpur-Dev) (5,778 stars)
-- [**MS-Agent**](https://github.com/modelscope/ms-agent) - Lightweight framework by ModelScope to empower agentic execution of complex tasks with memory and deep research. by [@modelscope](https://github.com/modelscope) (4,368 stars)
+- [**dify**](https://github.com/langgenius/dify#readme) - Production-ready platform for building agentic AI workflows with visual orchestration. by [@langgenius](https://github.com/langgenius) (153,529 stars)
+- [**LangChain**](https://github.com/langchain-ai/langchain#readme) - Full-stack agent engineering platform with composable chains, tools, and memory integration. by [@langchain-ai](https://github.com/langchain-ai) (145,010 stars)
+- [**OpenHands**](https://github.com/OpenHands/OpenHands#readme) - Open platform for AI software developers as generalist agents. Autonomous coding, debugging, and deployment. by [@OpenHands](https://github.com/OpenHands) (85,122 stars)
+- [**CowAgent**](https://github.com/zhayujie/CowAgent#readme) - Super AI assistant based on LLMs with autonomous thinking, task planning, skill creation, and long-term memory. by [@zhayujie](https://github.com/zhayujie) (46,678 stars)
+- [**agno**](https://github.com/agno-agi/agno#readme) - Production-ready agent framework that turns agents into deployable services with multi-framework support. by [@agno-agi](https://github.com/agno-agi) (41,928 stars)
+- [**langgraph**](https://github.com/langchain-ai/langgraph#readme) - Build resilient language agents as stateful graphs with persistence and streaming. by [@langchain-ai](https://github.com/langchain-ai) (40,466 stars)
+- [**CoPaw**](https://github.com/agentscope-ai/QwenPaw#readme) - Co Personal Agent Workstation built on AgentScope. Desktop agent platform with multi-agent collaboration and tool integration. by [@agentscope-ai](https://github.com/agentscope-ai) (34,476 stars)
+- [**mastra**](https://github.com/mastra-ai/mastra#readme) - TypeScript framework for building AI-powered applications with agent workflows and RAG. by [@mastra-ai](https://github.com/mastra-ai) (27,477 stars)
+- [**AgenticSeek**](https://github.com/Fosowl/agenticSeek#readme) - Fully local autonomous agent with browsing, coding, and multi-agent capabilities. No API keys required. by [@Fosowl](https://github.com/Fosowl) (27,017 stars)
+- [**haystack**](https://github.com/deepset-ai/haystack#readme) - Open-source AI orchestration framework for building context-engineered production applications. by [@deepset-ai](https://github.com/deepset-ai) (26,318 stars)
+- [**Coze Studio**](https://github.com/coze-dev/coze-studio#readme) - AI agent development platform with visual tools for creating, debugging, and deploying agents. by [@coze-dev](https://github.com/coze-dev) (21,503 stars)
+- [**Google ADK**](https://github.com/google/adk-python#readme) - Open-source Python toolkit by Google for building, evaluating, and deploying sophisticated AI agents. by [@google](https://github.com/google) (21,290 stars)
+- [**PydanticAI**](https://github.com/pydantic/pydantic-ai#readme) - Type-safe AI agent framework built on Pydantic with structured outputs and dependency injection. by [@pydantic](https://github.com/pydantic) (19,502 stars)
+- [**Parlant**](https://github.com/emcie-co/parlant#readme) - The conversational control layer for customer-facing AI agents. A context-engineering framework for controlling interactions. by [@emcie-co](https://github.com/emcie-co) (18,269 stars)
+- [**OpenFang**](https://github.com/RightNow-AI/openfang#readme) - Open-source Agent Operating System for deploying and managing AI agents. by [@RightNow-AI](https://github.com/RightNow-AI) (18,136 stars)
+- [**agents**](https://github.com/livekit/agents#readme) - Framework for building realtime voice AI agents with speech-to-speech pipelines. by [@livekit](https://github.com/livekit) (13,166 stars)
+- [**ten-framework**](https://github.com/TEN-framework/ten-framework#readme) - Open-source framework for building conversational voice AI agents. by [@TEN-framework](https://github.com/TEN-framework) (11,081 stars)
+- [**Agent-Squad**](https://github.com/2FastLabs/agent-squad#readme) - Flexible framework for managing multiple AI agents and handling complex conversations. by [@2FastLabs](https://github.com/2FastLabs) (7,747 stars)
+- [**PySpur**](https://github.com/PySpur-Dev/pyspur#readme) - Visual playground for agentic workflows with rapid iteration on multi-agent pipelines. by [@PySpur-Dev](https://github.com/PySpur-Dev) (5,778 stars)
+- [**MS-Agent**](https://github.com/modelscope/ms-agent#readme) - Lightweight framework by ModelScope to empower agentic execution of complex tasks with memory and deep research. by [@modelscope](https://github.com/modelscope) (4,368 stars)
 <!-- /AUTOGEN:platforms -->
 
 ## Agent Coding and Software Engineering
@@ -130,32 +131,59 @@ Platforms and tools for building, deploying, and managing AI agents.
 AI agents that write, debug, and maintain code autonomously.
 
 <!-- AUTOGEN:coding -->
-- [**Claude Code**](https://github.com/anthropics/claude-code) - Terminal-native agentic coding tool from Anthropic. Understands your codebase and executes tasks through natural language. by [@anthropics](https://github.com/anthropics) (143,032 stars)
-- [**Codex**](https://github.com/openai/codex) - Lightweight coding agent from OpenAI written in Rust. Runs locally as CLI, IDE extension, or desktop app. by [@OpenAI](https://github.com/OpenAI) (118,373 stars)
-- [**Pi**](https://github.com/earendil-works/pi) - Self-extensible coding agent and agent harness. Bundles an interactive coding CLI, an agent runtime with tool calling and state, and a unified multi-provider LLM API. by [@earendil-works](https://github.com/earendil-works) (97,415 stars)
-- [**agent-skills**](https://github.com/addyosmani/agent-skills) - Production-grade engineering skills and best practices for AI coding agents. by [@addyosmani](https://github.com/addyosmani) (89,814 stars)
-- [**Taste-Skill**](https://github.com/Leonxlnx/taste-skill) - High-Agency frontend skill that helps AI generate less generic, more tasteful outputs. by [@Leonxlnx](https://github.com/Leonxlnx) (80,671 stars)
-- [**Cline**](https://github.com/cline/cline) - Autonomous coding agent available as an IDE extension, CLI, or SDK. Plans and executes multi-step edits with human-in-the-loop approval. by [@cline](https://github.com/cline) (66,858 stars)
-- [**goose**](https://github.com/aaif-goose/goose) - Open-source extensible AI coding agent that goes beyond code suggestions. by [@aaif-goose](https://github.com/aaif-goose) (53,480 stars)
-- [**Aider**](https://github.com/Aider-AI/aider) - AI pair programming in your terminal. Edit code with LLMs across 100+ languages with deep Git integration. by [@Aider-AI](https://github.com/Aider-AI) (48,494 stars)
-- [**Qwen Code**](https://github.com/QwenLM/qwen-code) - Open-source AI coding agent that lives in your terminal, optimized for Qwen-Coder models. by [@QwenLM](https://github.com/QwenLM) (27,384 stars)
-- [**context-mode**](https://github.com/mksglu/context-mode) - Context window optimization tool for AI coding agents with sandboxed tool output and 98% token reduction. by [@mksglu](https://github.com/mksglu) (20,147 stars)
-- [**SWE-Agent**](https://github.com/SWE-agent/SWE-agent) - Automatically fix GitHub issues and handle cybersecurity challenges. State-of-the-art on SWE-bench. by [@SWE-agent](https://github.com/SWE-agent) (20,142 stars)
-- [**Devika**](https://github.com/stitionai/devika) - The first open-source implementation of an Agentic Software Engineer. An open-source alternative to Devin. by [@stitionai](https://github.com/stitionai) (19,560 stars)
-- [**Plandex**](https://github.com/plandex-ai/plandex) - Open-source AI coding agent designed for large projects and complex real-world tasks with persistent context. by [@plandex-ai](https://github.com/plandex-ai) (15,596 stars)
-- [**Trae Agent**](https://github.com/bytedance/trae-agent) - LLM-based agent by ByteDance for general-purpose software engineering tasks. by [@bytedance](https://github.com/bytedance) (12,055 stars)
-- [**Open SWE**](https://github.com/langchain-ai/open-swe) - Open-source asynchronous coding agent by LangChain for software engineering tasks. by [@langchain-ai](https://github.com/langchain-ai) (10,615 stars)
-- [**Mini-SWE-Agent**](https://github.com/SWE-agent/mini-swe-agent) - The 100-line AI agent that solves GitHub issues. Radically simple but scores >74% on SWE-bench verified. by [@SWE-agent](https://github.com/SWE-agent) (6,757 stars)
-- [**Reflexion**](https://github.com/noahshinn/reflexion) - Language agents with verbal reinforcement learning. Agents that learn from mistakes through self-reflection. by [@noahshinn](https://github.com/noahshinn) (3,242 stars)
+- [**Claude Code**](https://github.com/anthropics/claude-code#readme) - Terminal-native agentic coding tool from Anthropic. Understands your codebase and executes tasks through natural language. by [@anthropics](https://github.com/anthropics) (143,032 stars)
+- [**Codex**](https://github.com/openai/codex#readme) - Lightweight coding agent from OpenAI written in Rust. Runs locally as CLI, IDE extension, or desktop app. by [@OpenAI](https://github.com/OpenAI) (118,373 stars)
+- [**Pi**](https://github.com/earendil-works/pi#readme) - Self-extensible coding agent and agent harness. Bundles an interactive coding CLI, an agent runtime with tool calling and state, and a unified multi-provider LLM API. by [@earendil-works](https://github.com/earendil-works) (97,415 stars)
+- [**agent-skills**](https://github.com/addyosmani/agent-skills#readme) - Production-grade engineering skills and best practices for AI coding agents. by [@addyosmani](https://github.com/addyosmani) (89,814 stars)
+- [**Taste-Skill**](https://github.com/Leonxlnx/taste-skill#readme) - High-Agency frontend skill that helps AI generate less generic, more tasteful outputs. by [@Leonxlnx](https://github.com/Leonxlnx) (80,671 stars)
+- [**Cline**](https://github.com/cline/cline#readme) - Autonomous coding agent available as an IDE extension, CLI, or SDK. Plans and executes multi-step edits with human-in-the-loop approval. by [@cline](https://github.com/cline) (66,858 stars)
+- [**goose**](https://github.com/aaif-goose/goose#readme) - Open-source extensible AI coding agent that goes beyond code suggestions. by [@aaif-goose](https://github.com/aaif-goose) (53,480 stars)
+- [**Aider**](https://github.com/Aider-AI/aider#readme) - AI pair programming in your terminal. Edit code with LLMs across 100+ languages with deep Git integration. by [@Aider-AI](https://github.com/Aider-AI) (48,494 stars)
+- [**Qwen Code**](https://github.com/QwenLM/qwen-code#readme) - Open-source AI coding agent that lives in your terminal, optimized for Qwen-Coder models. by [@QwenLM](https://github.com/QwenLM) (27,384 stars)
+- [**context-mode**](https://github.com/mksglu/context-mode#readme) - Context window optimization tool for AI coding agents with sandboxed tool output and 98% token reduction. by [@mksglu](https://github.com/mksglu) (20,147 stars)
+- [**SWE-Agent**](https://github.com/SWE-agent/SWE-agent#readme) - Automatically fix GitHub issues and handle cybersecurity challenges. State-of-the-art on SWE-bench. by [@SWE-agent](https://github.com/SWE-agent) (20,142 stars)
+- [**Devika**](https://github.com/stitionai/devika#readme) - The first open-source implementation of an Agentic Software Engineer. An open-source alternative to Devin. by [@stitionai](https://github.com/stitionai) (19,560 stars)
+- [**Plandex**](https://github.com/plandex-ai/plandex#readme) - Open-source AI coding agent designed for large projects and complex real-world tasks with persistent context. by [@plandex-ai](https://github.com/plandex-ai) (15,596 stars)
+- [**Trae Agent**](https://github.com/bytedance/trae-agent#readme) - LLM-based agent by ByteDance for general-purpose software engineering tasks. by [@bytedance](https://github.com/bytedance) (12,055 stars)
+- [**Open SWE**](https://github.com/langchain-ai/open-swe#readme) - Open-source asynchronous coding agent by LangChain for software engineering tasks. by [@langchain-ai](https://github.com/langchain-ai) (10,615 stars)
+- [**Mini-SWE-Agent**](https://github.com/SWE-agent/mini-swe-agent#readme) - The 100-line AI agent that solves GitHub issues. Radically simple but scores >74% on SWE-bench verified. by [@SWE-agent](https://github.com/SWE-agent) (6,757 stars)
+- [**Reflexion**](https://github.com/noahshinn/reflexion#readme) - Language agents with verbal reinforcement learning. Agents that learn from mistakes through self-reflection. by [@noahshinn](https://github.com/noahshinn) (3,242 stars)
 <!-- /AUTOGEN:coding -->
 
-## Prompt and Behaviour Optimization
+## Multi-Agent Frameworks
+
+Multi-agent frameworks and collaborative agent systems that are relevant to agent evolution and infrastructure.
+
+<!-- AUTOGEN:multi-agent -->
+- [**MetaGPT**](https://github.com/FoundationAgents/MetaGPT#readme) - Multi-agent framework that assigns roles to GPTs to form a collaborative software entity. by [@FoundationAgents](https://github.com/FoundationAgents) (70,036 stars)
+- [**autogen**](https://github.com/microsoft/autogen#readme) - Programming framework for building agentic AI systems with multi-agent conversations. by [@microsoft](https://github.com/microsoft) (60,632 stars)
+- [**crewAI**](https://github.com/crewAIInc/crewAI#readme) - Framework for orchestrating role-playing autonomous AI agents for collaborative task execution. by [@crewAIInc](https://github.com/crewAIInc) (57,616 stars)
+- [**Vibe-Trading**](https://github.com/HKUDS/Vibe-Trading#readme) - Personal trading agent for multi-agent market analysis and backtesting. by [@HKUDS](https://github.com/HKUDS) (31,723 stars)
+- [**agentscope**](https://github.com/agentscope-ai/agentscope#readme) - Multi-agent platform for building agents you can see, understand and trust. by [@agentscope-ai](https://github.com/agentscope-ai) (29,626 stars)
+- [**openai-agents-python**](https://github.com/openai/openai-agents-python#readme) - Lightweight framework for multi-agent workflows by OpenAI. by [@openai](https://github.com/openai) (28,969 stars)
+- [**GenAI Agents**](https://github.com/NirDiamant/GenAI_Agents#readme) - Comprehensive tutorials and implementations covering 50+ generative AI agent techniques from basic to advanced. by [@NirDiamant](https://github.com/NirDiamant) (23,988 stars)
+- [**swarm**](https://github.com/openai/swarm#readme) - Educational framework exploring ergonomic lightweight multi-agent orchestration by OpenAI. by [@openai](https://github.com/openai) (21,923 stars)
+- [**camel**](https://github.com/camel-ai/camel#readme) - Multi-agent framework for finding the scaling law of agents through role-playing communication. by [@camel-ai](https://github.com/camel-ai) (17,639 stars)
+- [**agent-framework**](https://github.com/microsoft/agent-framework#readme) - Framework for building, orchestrating and deploying AI agents and multi-agent systems. by [@microsoft](https://github.com/microsoft) (13,118 stars)
+- [**PraisonAI**](https://github.com/MervinPraison/PraisonAI#readme) - AI employee team platform that automates and solves complex challenges with multi-agent collaboration. by [@MervinPraison](https://github.com/MervinPraison) (8,958 stars)
+- [**swarms**](https://github.com/kyegomez/swarms#readme) - Enterprise-grade production-ready multi-agent orchestration framework. by [@kyegomez](https://github.com/kyegomez) (7,086 stars)
+- [**MindSearch**](https://github.com/InternLM/MindSearch#readme) - LLM-based multi-agent framework for web search engines with deep information seeking. by [@InternLM](https://github.com/InternLM) (6,917 stars)
+- [**open-multi-agent**](https://github.com/open-multi-agent/open-multi-agent#readme) - TypeScript multi-agent framework with one function call from goal to result. by [@open-multi-agent](https://github.com/open-multi-agent) (6,829 stars)
+- [**agency-swarm**](https://github.com/VRSEN/agency-swarm#readme) - Reliable multi-agent orchestration framework for building AI agent swarms. by [@VRSEN](https://github.com/VRSEN) (4,540 stars)
+- [**Golutra**](https://github.com/golutra/golutra#readme) - Multi-agent AI orchestration platform for automation, workflows, and developer tools. by [@golutra](https://github.com/golutra) (3,830 stars)
+- [**GoClaw**](https://github.com/nextlevelbuilder/goclaw#readme) - OpenClaw rebuilt in Go with multi-tenant isolation, 5-layer security, and native concurrency for deploying AI agent teams at scale. by [@nextlevelbuilder](https://github.com/nextlevelbuilder) (3,564 stars)
+- [**BotSharp**](https://github.com/SciSharp/BotSharp#readme) - AI multi-agent framework built on .NET for enterprise conversational applications. by [@SciSharp](https://github.com/SciSharp) (3,098 stars)
+- [**agentUniverse**](https://github.com/agentuniverse-ai/agentUniverse#readme) - LLM multi-agent framework for building, customizing and running collaborative agents. by [@agentuniverse-ai](https://github.com/agentuniverse-ai) (2,341 stars)
+- [**LLMStack**](https://github.com/trypromptly/LLMStack#readme) - No-code multi-agent framework for building LLM agent workflows and applications. by [@trypromptly](https://github.com/trypromptly) (2,311 stars)
+- [**Sage**](https://github.com/ZHangZHengEric/Sage#readme) - Multi-agent system framework for complex tasks. by [@ZHangZHengEric](https://github.com/ZHangZHengEric) (1,207 stars)
+<!-- /AUTOGEN:multi-agent -->
+
 
 Tools and frameworks for automatically optimizing agent prompts, instructions, and behavioral patterns.
 
 <!-- AUTOGEN:prompt-optimization -->
-- [**Promptfoo**](https://github.com/promptfoo/promptfoo) - Open-source LLM evaluation and red-teaming framework. Test prompts, agents, and RAGs with 90+ model providers and 67+ security plugins. by [@promptfoo](https://github.com/promptfoo) (24,576 stars)
-- [**TextGrad**](https://github.com/zou-group/textgrad) - Automatic differentiation via text. Backpropagation through LLM-provided textual gradients, published in Nature. by [@zou-group](https://github.com/zou-group) (3,706 stars)
+- [**Promptfoo**](https://github.com/promptfoo/promptfoo#readme) - Open-source LLM evaluation and red-teaming framework. Test prompts, agents, and RAGs with 90+ model providers and 67+ security plugins. by [@promptfoo](https://github.com/promptfoo) (24,576 stars)
+- [**TextGrad**](https://github.com/zou-group/textgrad#readme) - Automatic differentiation via text. Backpropagation through LLM-provided textual gradients, published in Nature. by [@zou-group](https://github.com/zou-group) (3,706 stars)
 <!-- /AUTOGEN:prompt-optimization -->
 
 ## Agent Safety and Guardrails
@@ -163,8 +191,8 @@ Tools and frameworks for automatically optimizing agent prompts, instructions, a
 Projects focused on controlling agent actions, enforcing policies, and preventing harmful behavior.
 
 <!-- AUTOGEN:safety -->
-- [**NeMo Guardrails**](https://github.com/NVIDIA-NeMo/Guardrails) - NVIDIA's toolkit for adding programmable guardrails to LLM conversational systems. Policy-based safety controls. by [@NVIDIA-NeMo](https://github.com/NVIDIA-NeMo) (7,014 stars)
-- [**AgentDoG**](https://github.com/AI45Lab/AgentDoG) - Diagnostic guardrail framework for AI agent safety and security. Detects and intercepts unsafe agent behavior at runtime. by [@AI45Lab](https://github.com/AI45Lab) (685 stars)
+- [**NeMo Guardrails**](https://github.com/NVIDIA-NeMo/Guardrails#readme) - NVIDIA's toolkit for adding programmable guardrails to LLM conversational systems. Policy-based safety controls. by [@NVIDIA-NeMo](https://github.com/NVIDIA-NeMo) (7,014 stars)
+- [**AgentDoG**](https://github.com/AI45Lab/AgentDoG#readme) - Diagnostic guardrail framework for AI agent safety and security. Detects and intercepts unsafe agent behavior at runtime. by [@AI45Lab](https://github.com/AI45Lab) (685 stars)
 <!-- /AUTOGEN:safety -->
 
 ## Embodied AI
@@ -172,14 +200,14 @@ Projects focused on controlling agent actions, enforcing policies, and preventin
 Projects connecting AI agents to physical devices, robotics, and real-world environments.
 
 <!-- AUTOGEN:embodied -->
-- [**LeRobot**](https://github.com/huggingface/lerobot) - Open-source robotics framework by Hugging Face. Models, datasets, and tools for real-world robotics in PyTorch. (26,920 stars)
-- [**Open-AutoGLM**](https://github.com/zai-org/Open-AutoGLM) - An Open Phone Agent Model and Framework. Unlocking the AI Phone for Everyone. by [@zai-org](https://github.com/zai-org) (26,087 stars)
-- [**Nanobrowser**](https://github.com/nanobrowser/nanobrowser) - Chrome extension for AI-powered web automation. Run multi-agent workflows using your own AI keys. by [@nanobrowser](https://github.com/nanobrowser) (13,675 stars)
-- [**XcodeBuildMCP**](https://github.com/getsentry/XcodeBuildMCP) - A MCP server and CLI for agent use when working on iOS and macOS projects. by [@getsentry](https://github.com/getsentry) (6,287 stars)
-- [**Mobile MCP**](https://github.com/mobile-next/mobile-mcp) - Model Context Protocol Server for Mobile Automation and Scraping (iOS, Android, Emulators and Real Devices). by [@mobile-next](https://github.com/mobile-next) (6,017 stars)
-- [**agent-device**](https://github.com/callstack/agent-device) - CLI that lets AI agents drive real iOS and Android devices — taps, text input, screenshots, and app control for mobile automation. by [@callstack](https://github.com/callstack) (4,221 stars)
-- [**ROS-LLM**](https://github.com/Auromix/ROS-LLM) - Framework for embodied intelligence in ROS. Natural language interactions with LLMs for robot control. by [@Auromix](https://github.com/Auromix) (829 stars)
-- [**RAI**](https://github.com/RobotecAI/rai) - Vendor-agnostic agentic framework for Physical AI and robotics. Connects LLM agents to ROS 2 tools for perception, reasoning, and control. by [@RobotecAI](https://github.com/RobotecAI) (574 stars)
+- [**LeRobot**](https://github.com/huggingface/lerobot#readme) - Open-source robotics framework by Hugging Face. Models, datasets, and tools for real-world robotics in PyTorch. by [@huggingface](https://github.com/huggingface) (26,920 stars)
+- [**Open-AutoGLM**](https://github.com/zai-org/Open-AutoGLM#readme) - An Open Phone Agent Model and Framework. Unlocking the AI Phone for Everyone. by [@zai-org](https://github.com/zai-org) (26,087 stars)
+- [**Nanobrowser**](https://github.com/nanobrowser/nanobrowser#readme) - Chrome extension for AI-powered web automation. Run multi-agent workflows using your own AI keys. by [@nanobrowser](https://github.com/nanobrowser) (13,675 stars)
+- [**XcodeBuildMCP**](https://github.com/getsentry/XcodeBuildMCP#readme) - A MCP server and CLI for agent use when working on iOS and macOS projects. by [@getsentry](https://github.com/getsentry) (6,287 stars)
+- [**Mobile MCP**](https://github.com/mobile-next/mobile-mcp#readme) - Model Context Protocol Server for Mobile Automation and Scraping (iOS, Android, Emulators and Real Devices). by [@mobile-next](https://github.com/mobile-next) (6,017 stars)
+- [**agent-device**](https://github.com/callstack/agent-device#readme) - CLI that lets AI agents drive real iOS and Android devices — taps, text input, screenshots, and app control for mobile automation. by [@callstack](https://github.com/callstack) (4,221 stars)
+- [**ROS-LLM**](https://github.com/Auromix/ROS-LLM#readme) - Framework for embodied intelligence in ROS. Natural language interactions with LLMs for robot control. by [@Auromix](https://github.com/Auromix) (829 stars)
+- [**RAI**](https://github.com/RobotecAI/rai#readme) - Vendor-agnostic agentic framework for Physical AI and robotics. Connects LLM agents to ROS 2 tools for perception, reasoning, and control. by [@RobotecAI](https://github.com/RobotecAI) (574 stars)
 <!-- /AUTOGEN:embodied -->
 
 ## Key Research Papers
@@ -263,7 +291,7 @@ Projects connecting AI agents to physical devices, robotics, and real-world envi
 ## Community and Knowledge
 
 <!-- AUTOGEN:community -->
-- [**Awesome-Self-Evolving-Agents**](https://github.com/EvoAgentX/Awesome-Self-Evolving-Agents) - A comprehensive survey of self-evolving AI agents. Covers single-agent optimization, multi-agent optimization, and domain-specific approaches. by [@EvoAgentX](https://github.com/EvoAgentX) (2,456 stars)
+- [**Awesome-Self-Evolving-Agents**](https://github.com/ANative-Lab/Awesome-Self-Evolving-Agents#readme) - A comprehensive survey of self-evolving AI agents. Covers single-agent optimization, multi-agent optimization, and domain-specific approaches. by [@ANative-Lab](https://github.com/ANative-Lab) (2,456 stars)
 <!-- /AUTOGEN:community -->
 
 ## Footnotes

--- a/data/projects.json
+++ b/data/projects.json
@@ -66,10 +66,10 @@
   },
   {
     "name": "EvoAgentX",
-    "repo": "EvoAgentX/EvoAgentX",
+    "repo": "ANative-Lab/EvoAgentX",
     "description": "Automated framework for evolving agentic workflows. Optimizes agent prompts, tools, and pipelines via evolutionary algorithms.",
     "category": "evolution",
-    "maintainer": "EvoAgentX",
+    "maintainer": "ANative-Lab",
     "tags": [
       "workflow-evolution",
       "prompt-optimization",
@@ -716,7 +716,8 @@
       "pytorch",
       "hugging-face"
     ],
-    "stars": 26920
+    "stars": 26920,
+    "maintainer": "huggingface"
   },
   {
     "name": "Nanobrowser",
@@ -772,10 +773,10 @@
   },
   {
     "name": "Awesome-Self-Evolving-Agents",
-    "repo": "EvoAgentX/Awesome-Self-Evolving-Agents",
+    "repo": "ANative-Lab/Awesome-Self-Evolving-Agents",
     "description": "A comprehensive survey of self-evolving AI agents. Covers single-agent optimization, multi-agent optimization, and domain-specific approaches.",
     "category": "community",
-    "maintainer": "EvoAgentX",
+    "maintainer": "ANative-Lab",
     "tags": [
       "survey",
       "research",
@@ -906,7 +907,11 @@
     "description": "Educational framework exploring ergonomic lightweight multi-agent orchestration by OpenAI.",
     "category": "multi-agent",
     "maintainer": "openai",
-    "tags": [],
+    "tags": [
+      "multi-agent",
+      "orchestration",
+      "educational"
+    ],
     "stars": 21923
   },
   {
@@ -1045,7 +1050,11 @@
     "description": "Reliable multi-agent orchestration framework for building AI agent swarms.",
     "category": "multi-agent",
     "maintainer": "VRSEN",
-    "tags": [],
+    "tags": [
+      "multi-agent",
+      "orchestration",
+      "role-based"
+    ],
     "stars": 4540
   },
   {
@@ -1233,7 +1242,7 @@
   {
     "name": "Golutra",
     "repo": "golutra/golutra",
-    "description": "Multi-agent AI orchestration platform for automation, workflows, and developer tools. Golutra transforms Codex, Claude Code, and OpenClaw into a unified agent system with parallel execution, task orch",
+    "description": "Multi-agent AI orchestration platform for automation, workflows, and developer tools.",
     "category": "multi-agent",
     "maintainer": "golutra",
     "tags": [
@@ -1258,7 +1267,7 @@
   {
     "name": "Vibe-Trading",
     "repo": "HKUDS/Vibe-Trading",
-    "description": "\"Vibe-Trading: Your Personal Trading Agent\"",
+    "description": "Personal trading agent for multi-agent market analysis and backtesting.",
     "category": "multi-agent",
     "maintainer": "HKUDS",
     "tags": [
@@ -1323,34 +1332,46 @@
   {
     "name": "Cline",
     "repo": "cline/cline",
-    "description": "Autonomous coding agent available as an IDE extension, CLI, or SDK. Plans and executes multi-step edits with human-in-the-loop approval",
+    "description": "Autonomous coding agent available as an IDE extension, CLI, or SDK. Plans and executes multi-step edits with human-in-the-loop approval.",
     "category": "coding",
     "maintainer": "cline",
-    "tags": [],
+    "tags": [
+      "coding-agent",
+      "ide",
+      "human-in-the-loop"
+    ],
     "stars": 66858
   },
   {
     "name": "Pi",
     "repo": "earendil-works/pi",
-    "description": "Self-extensible coding agent and agent harness. Bundles an interactive coding CLI, an agent runtime with tool calling and state, and a unified multi-provider LLM API",
+    "description": "Self-extensible coding agent and agent harness. Bundles an interactive coding CLI, an agent runtime with tool calling and state, and a unified multi-provider LLM API.",
     "category": "coding",
     "maintainer": "earendil-works",
-    "tags": [],
+    "tags": [
+      "coding-agent",
+      "agent-harness",
+      "multi-provider"
+    ],
     "stars": 97415
   },
   {
     "name": "Qwen Code",
     "repo": "QwenLM/qwen-code",
-    "description": "Open-source AI coding agent that lives in your terminal, optimized for Qwen-Coder models",
+    "description": "Open-source AI coding agent that lives in your terminal, optimized for Qwen-Coder models.",
     "category": "coding",
     "maintainer": "QwenLM",
-    "tags": [],
+    "tags": [
+      "coding-agent",
+      "terminal",
+      "qwen"
+    ],
     "stars": 27384
   },
   {
     "name": "agentmemory",
     "repo": "rohitg00/agentmemory",
-    "description": "Persistent, benchmark-tuned memory for coding agents (Claude Code, Cursor, Copilot CLI, Codex, and any MCP client). Remembers context across sessions so you stop re-explaining",
+    "description": "Persistent, benchmark-tuned memory for coding agents (Claude Code, Cursor, Copilot CLI, Codex, and any MCP client). Remembers context across sessions so you stop re-explaining.",
     "category": "memory",
     "maintainer": "rohitg00",
     "tags": [
@@ -1363,7 +1384,7 @@
   {
     "name": "TencentDB Agent Memory",
     "repo": "TencentCloud/TencentDB-Agent-Memory",
-    "description": "Fully local long-term memory for AI agents via a four-tier progressive storage architecture, from Tencent Cloud",
+    "description": "Fully local long-term memory for AI agents via a four-tier progressive storage architecture, from Tencent Cloud.",
     "category": "memory",
     "maintainer": "TencentCloud",
     "tags": [
@@ -1376,7 +1397,7 @@
   {
     "name": "agent-device",
     "repo": "callstack/agent-device",
-    "description": "CLI that lets AI agents drive real iOS and Android devices — taps, text input, screenshots, and app control for mobile automation",
+    "description": "CLI that lets AI agents drive real iOS and Android devices — taps, text input, screenshots, and app control for mobile automation.",
     "category": "embodied",
     "maintainer": "callstack",
     "tags": [
@@ -1389,16 +1410,20 @@
   {
     "name": "SIA",
     "repo": "hexo-ai/sia",
-    "description": "Self-improving AI framework that autonomously optimizes the performance of any AI system through iterative evaluation and refinement",
+    "description": "Self-improving AI framework that autonomously optimizes the performance of any AI system through iterative evaluation and refinement.",
     "category": "evolution",
     "maintainer": "hexo-ai",
-    "tags": [],
+    "tags": [
+      "self-improving",
+      "evaluation",
+      "optimization"
+    ],
     "stars": 2122
   },
   {
     "name": "arcade-mcp",
     "repo": "ArcadeAI/arcade-mcp",
-    "description": "MCP server framework and tool-development library for building custom agent capabilities and authenticated tool calls",
+    "description": "MCP server framework and tool-development library for building custom agent capabilities and authenticated tool calls.",
     "category": "protocols",
     "maintainer": "ArcadeAI",
     "tags": [
@@ -1411,16 +1436,20 @@
   {
     "name": "AgentDoG",
     "repo": "AI45Lab/AgentDoG",
-    "description": "Diagnostic guardrail framework for AI agent safety and security. Detects and intercepts unsafe agent behavior at runtime",
+    "description": "Diagnostic guardrail framework for AI agent safety and security. Detects and intercepts unsafe agent behavior at runtime.",
     "category": "safety",
     "maintainer": "AI45Lab",
-    "tags": [],
+    "tags": [
+      "safety",
+      "guardrails",
+      "runtime"
+    ],
     "stars": 685
   },
   {
     "name": "RAI",
     "repo": "RobotecAI/rai",
-    "description": "Vendor-agnostic agentic framework for Physical AI and robotics. Connects LLM agents to ROS 2 tools for perception, reasoning, and control",
+    "description": "Vendor-agnostic agentic framework for Physical AI and robotics. Connects LLM agents to ROS 2 tools for perception, reasoning, and control.",
     "category": "embodied",
     "maintainer": "RobotecAI",
     "tags": [
@@ -1433,10 +1462,14 @@
   {
     "name": "A2A x402",
     "repo": "google-agentic-commerce/a2a-x402",
-    "description": "A2A protocol extension adding x402 on-chain payments, letting agents monetize services over Agent-to-Agent calls",
+    "description": "A2A protocol extension adding x402 on-chain payments, letting agents monetize services over Agent-to-Agent calls.",
     "category": "protocols",
     "maintainer": "google-agentic-commerce",
-    "tags": [],
+    "tags": [
+      "a2a",
+      "payments",
+      "protocol"
+    ],
     "stars": 553
   }
 ]

--- a/scripts/adopt-projects.js
+++ b/scripts/adopt-projects.js
@@ -5,6 +5,28 @@ const path = require('path');
 
 const PROJECTS_PATH = path.join(__dirname, '..', 'data', 'projects.json');
 const DISCOVERED_PATH = path.join(__dirname, '..', 'data', 'discovered.json');
+const CATEGORY_SECTIONS = {
+  evolution: true,
+  memory: true,
+  protocols: true,
+  platforms: true,
+  coding: true,
+  'multi-agent': true,
+  'prompt-optimization': true,
+  safety: true,
+  embodied: true,
+  community: true,
+};
+
+function validateCandidate(candidate) {
+  const errors = [];
+  if (typeof candidate.repo !== 'string' || !/^[^/\s]+\/[^/\s]+$/.test(candidate.repo)) errors.push('repo must be owner/name');
+  if (!CATEGORY_SECTIONS[candidate.suggestedCategory || 'community']) errors.push(`unknown category: ${candidate.suggestedCategory}`);
+  if (typeof candidate.description !== 'string' || !/^[A-Z]/.test(candidate.description.trim()) || !/[.!?。]$/.test(candidate.description.trim())) errors.push('description must start uppercase and end punctuation');
+  const tags = Array.isArray(candidate.topics) ? candidate.topics.filter(Boolean) : [];
+  if (tags.length < 2 || tags.length > 3) errors.push('candidate must provide 2-3 tags');
+  return errors;
+}
 
 function main() {
   if (!fs.existsSync(DISCOVERED_PATH)) {
@@ -29,6 +51,12 @@ function main() {
   for (const candidate of approved) {
     if (existingRepos.has(candidate.repo.toLowerCase())) {
       console.log(`  SKIP (already exists): ${candidate.repo}`);
+      continue;
+    }
+
+    const candidateErrors = validateCandidate(candidate);
+    if (candidateErrors.length > 0) {
+      console.error(`  REJECT: ${candidate.repo} -- ${candidateErrors.join('; ')}`);
       continue;
     }
 

--- a/scripts/generate-readme.js
+++ b/scripts/generate-readme.js
@@ -16,6 +16,7 @@ const CATEGORY_SECTIONS = {
   'safety': 'safety',
   'embodied': 'embodied',
   'community': 'community',
+  'multi-agent': 'multi-agent',
 };
 
 function formatProject(p) {
@@ -25,7 +26,7 @@ function formatProject(p) {
   }
   const maintainer = p.maintainer ? ` by [@${p.maintainer}](https://github.com/${p.maintainer})` : '';
   const stars = p.stars ? ` (${p.stars.toLocaleString()} stars)` : '';
-  return `- [**${p.name}**](https://github.com/${p.repo}) - ${desc}${maintainer}${stars}`;
+  return `- [**${p.name}**](https://github.com/${p.repo}#readme) - ${desc}${maintainer}${stars}`;
 }
 
 function main() {

--- a/scripts/update-stars.js
+++ b/scripts/update-stars.js
@@ -10,7 +10,7 @@
  * Requires: gh CLI authenticated
  */
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
@@ -24,9 +24,9 @@ function sleep(ms) {
 
 function fetchStars(repo) {
   try {
-    const cmd = `gh api repos/${repo} --jq '.stargazers_count'`;
-    const result = execSync(cmd, { encoding: 'utf-8', timeout: 15000 }).trim();
-    return parseInt(result, 10);
+    const result = execFileSync('gh', ['api', `repos/${repo}`, '--jq', '.stargazers_count'], { encoding: 'utf-8', timeout: 15000 }).trim();
+    const stars = Number.parseInt(result, 10);
+    return Number.isInteger(stars) && stars >= 0 ? stars : null;
   } catch (e) {
     console.warn(`  Failed to fetch ${repo}: ${e.message.split('\n')[0]}`);
     return null;
@@ -70,6 +70,12 @@ async function main() {
   }
 
   console.log(`\nResults: ${updated} updated, ${failed} failed`);
+
+  if (failed > 0) {
+    console.error('Star refresh incomplete; refusing to write a partial snapshot.');
+    process.exitCode = 1;
+    return;
+  }
 
   if (!dryRun && updated > 0) {
     fs.writeFileSync(PROJECTS_PATH, JSON.stringify(projects, null, 2) + '\n', 'utf-8');

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+/** Validate the curated project data and generated README. */
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const PROJECTS_PATH = path.join(ROOT, 'data', 'projects.json');
+const README_PATH = path.join(ROOT, 'README.md');
+const GENERATOR_PATH = path.join(ROOT, 'scripts', 'generate-readme.js');
+const CATEGORY_SECTIONS = {
+  evolution: 'evolution',
+  memory: 'memory',
+  protocols: 'protocols',
+  platforms: 'platforms',
+  coding: 'coding',
+  'multi-agent': 'multi-agent',
+  'prompt-optimization': 'prompt-optimization',
+  safety: 'safety',
+  embodied: 'embodied',
+  community: 'community',
+};
+const PLACEHOLDER_RE = /(?:xxxxx|owner\/repo|example\.com|TODO|FIXME)/i;
+const errors = [];
+const warn = message => console.warn(`WARN: ${message}`);
+const fail = (message, index) => errors.push(index === undefined ? message : `projects[${index}]: ${message}`);
+
+function loadJson(file) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); }
+  catch (error) { fail(`${path.relative(ROOT, file)} is not valid JSON: ${error.message}`); return null; }
+}
+
+function validateProjects(projects) {
+  if (!Array.isArray(projects)) { fail('data/projects.json must contain an array'); return; }
+  const seen = new Map();
+  for (const [index, project] of projects.entries()) {
+    if (!project || typeof project !== 'object' || Array.isArray(project)) { fail('must be an object', index); continue; }
+    for (const key of ['name', 'repo', 'description', 'category', 'maintainer', 'tags', 'stars']) {
+      if (!(key in project)) fail(`missing ${key}`, index);
+    }
+    if (typeof project.name !== 'string' || !project.name.trim()) fail('name must be a non-empty string', index);
+    if (typeof project.repo !== 'string' || !/^[^/\s]+\/[^/\s]+$/.test(project.repo)) fail('repo must be owner/name', index);
+    const repoKey = String(project.repo).toLowerCase();
+    if (seen.has(repoKey)) fail(`duplicate repo (also projects[${seen.get(repoKey)}])`, index); else seen.set(repoKey, index);
+    if (typeof project.category !== 'string' || !(project.category in CATEGORY_SECTIONS)) fail(`unknown category ${project.category}`, index);
+    if (typeof project.maintainer !== 'string' || !project.maintainer.trim()) fail('maintainer must be a non-empty string', index);
+    else if (typeof project.repo === 'string' && project.maintainer.toLowerCase() !== project.repo.split('/')[0].toLowerCase()) fail(`maintainer must match repo owner (${project.repo.split('/')[0]})`, index);
+    if (!Array.isArray(project.tags) || project.tags.length < 2 || project.tags.length > 3 || project.tags.some(tag => typeof tag !== 'string' || !tag.trim())) fail('tags must contain 2-3 non-empty strings', index);
+    if (typeof project.description !== 'string' || !/^[A-Z]/.test(project.description.trim()) || !/[.!?。]$/.test(project.description.trim()) || PLACEHOLDER_RE.test(project.description)) fail('description must start uppercase, end punctuation, and contain no placeholder', index);
+    if (!Number.isInteger(project.stars) || project.stars < 0) fail('stars must be a non-negative integer', index);
+    if (project.paper !== undefined && (typeof project.paper !== 'string' || !/^https:\/\//.test(project.paper) || PLACEHOLDER_RE.test(project.paper))) fail('paper must be a real HTTPS URL', index);
+  }
+}
+
+function validateReadme(projects, readme) {
+  if (typeof readme !== 'string') return;
+  if (PLACEHOLDER_RE.test(readme)) fail('README contains a placeholder token or example URL');
+  for (const [category, section] of Object.entries(CATEGORY_SECTIONS)) {
+    const regex = new RegExp(`<!-- AUTOGEN:${section} -->([\\s\\S]*?)<!-- /AUTOGEN:${section} -->`);
+    const match = readme.match(regex);
+    if (!match) { fail(`README is missing AUTOGEN:${section} markers`); continue; }
+    const expected = projects.filter(project => project.category === category).sort((a, b) => (b.stars || 0) - (a.stars || 0));
+    const actualRepos = [...match[1].matchAll(/^- \[\*\*[^\n]+?\*\*\]\(https:\/\/github\.com\/([^\)#]+)(?:#readme)?\)/gm)].map(m => m[1].toLowerCase());
+    const expectedRepos = expected.map(project => project.repo.toLowerCase());
+    if (actualRepos.length !== expectedRepos.length || actualRepos.some((repo, index) => repo !== expectedRepos[index])) fail(`README category ${category} does not match generated project order`);
+  }
+  for (const [lineNumber, line] of readme.split('\n').entries()) {
+    for (const url of line.matchAll(/https?:\/\/[^\s)]+/g)) {
+      if (!/^https:\/\//.test(url[0])) warn(`README line ${lineNumber + 1} uses a non-HTTPS URL: ${url[0]}`);
+      if (PLACEHOLDER_RE.test(url[0])) fail(`README line ${lineNumber + 1} contains placeholder URL ${url[0]}`);
+    }
+  }
+}
+
+function validateGeneratedOutput() {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'awesome-validate-'));
+  try {
+    const tempReadme = path.join(temp, 'README.md');
+    fs.copyFileSync(README_PATH, tempReadme);
+    const tempDataDir = path.join(temp, 'data'); fs.mkdirSync(tempDataDir);
+    fs.copyFileSync(PROJECTS_PATH, path.join(tempDataDir, 'projects.json'));
+    const tempScriptDir = path.join(temp, 'scripts'); fs.mkdirSync(tempScriptDir);
+    const generator = fs.readFileSync(GENERATOR_PATH, 'utf8').replace(/path\.join\(__dirname, '..', 'data', 'projects\.json'\)/g, "path.join(__dirname, '..', 'data', 'projects.json')");
+    fs.writeFileSync(path.join(tempScriptDir, 'generate-readme.js'), generator);
+    execFileSync(process.execPath, [path.join(tempScriptDir, 'generate-readme.js')], { cwd: temp, stdio: 'pipe' });
+    if (fs.readFileSync(tempReadme, 'utf8') !== fs.readFileSync(README_PATH, 'utf8')) fail('README is not reproducible from data/projects.json');
+  } catch (error) { fail(`generator failed: ${error.message}`); }
+  finally { fs.rmSync(temp, { recursive: true, force: true }); }
+}
+
+const projects = loadJson(PROJECTS_PATH);
+const readme = fs.existsSync(README_PATH) ? fs.readFileSync(README_PATH, 'utf8') : (fail('README.md is missing'), null);
+validateProjects(projects);
+validateReadme(projects || [], readme);
+validateGeneratedOutput();
+console.log(`Validated ${projects?.length || 0} projects across ${Object.keys(CATEGORY_SECTIONS).length} categories`);
+if (errors.length) { console.error(`Validation failed with ${errors.length} error(s):`); errors.forEach(error => console.error(`- ${error}`)); process.exit(1); }
+console.log('Validation passed.');


### PR DESCRIPTION
## Summary
- restore the 21 `multi-agent` projects omitted by the README generator
- add fail-closed project/README validation and PR workflow
- normalize canonical links, metadata, contribution guidance, and star refresh behavior

## Verification
- `node scripts/generate-readme.js` (idempotent)
- `node scripts/validate.js` (113 projects, 10 categories, passed)
- `git diff --check`
- repository link check: 113 OK, 0 failures, 0 warnings

## Scope
Documentation, curation data, maintenance scripts, and CI only. No runtime application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)