### PR TITLE
chore: recover reviewed project contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ Projects focused on enabling AI agents to evolve, learn, and improve autonomousl
 - [**EvoAgentX**](https://github.com/ANative-Lab/EvoAgentX#readme) - Automated framework for evolving agentic workflows. Optimizes agent prompts, tools, and pipelines via evolutionary algorithms. by [@ANative-Lab](https://github.com/ANative-Lab) (3,253 stars)
 - [**HyperAgents**](https://github.com/facebookresearch/HyperAgents#readme) - Self-referential self-improving agents by Meta. DGM-Hyperagents add an optimization layer so agents edit their own improvement process. by [@facebookresearch](https://github.com/facebookresearch) (2,696 stars)
 - [**SIA**](https://github.com/hexo-ai/sia#readme) - Self-improving AI framework that autonomously optimizes the performance of any AI system through iterative evaluation and refinement. by [@hexo-ai](https://github.com/hexo-ai) (2,122 stars)
+- [**Orkas**](https://github.com/Orkas-AI/Orkas#readme) - Local-first multi-agent desktop application whose specialist agents improve through reflection and crystallize successful approaches into private reusable skills. by [@Orkas-AI](https://github.com/Orkas-AI) (1,545 stars)
 - [**Agent0**](https://github.com/aiming-lab/Agent0#readme) - Self-evolving agent framework from UNC/Salesforce/Stanford. Improves without human-curated datasets via curriculum and executor agent competition. by [@aiming-lab](https://github.com/aiming-lab) (1,254 stars)
 - [**Ouroboros**](https://github.com/razzant/ouroboros#readme) - Self-creating AI agent that writes its own code and evolves autonomously. Completed 30+ evolution cycles in first 24 hours with zero human intervention. by [@razzant](https://github.com/razzant) (1,228 stars)
+- [**agent-qa**](https://github.com/vostride/agent-qa#readme) - Self-improving QA agent for natural-language web and mobile tests, using persistent run memory to adapt to UI changes and catch regressions. Source-available under FSL-1.1-ALv2: use is permitted except to provide a competing commercial product or service, and each release converts to Apache-2.0 after two years. by [@vostride](https://github.com/vostride) (896 stars)
 - [**A-Evolve**](https://github.com/A-EVO-Lab/a-evolve#readme) - The PyTorch for Agentic AI. Open-source infrastructure that evolves any agent across any domain with zero human intervention. #1 on MCP-Atlas (79.4%). by [@A-EVO-Lab](https://github.com/A-EVO-Lab) (752 stars)
+- [**OpenProgram**](https://github.com/Fzkuji/OpenProgram#readme) - Self-programming AI agent framework whose agents create, run, and refine their own workflows while the runtime manages models, tools, memory, context, and multi-agent collaboration. by [@Fzkuji](https://github.com/Fzkuji) (324 stars)
 - [**SEAgent**](https://github.com/SunzeY/SEAgent#readme) - Self-Evolving Computer Use Agent with Autonomous Learning from Experience. by [@SunzeY](https://github.com/SunzeY) (263 stars)
 <!-- /AUTOGEN:evolution -->
 
@@ -148,6 +151,7 @@ AI agents that write, debug, and maintain code autonomously.
 - [**Open SWE**](https://github.com/langchain-ai/open-swe#readme) - Open-source asynchronous coding agent by LangChain for software engineering tasks. by [@langchain-ai](https://github.com/langchain-ai) (10,615 stars)
 - [**Mini-SWE-Agent**](https://github.com/SWE-agent/mini-swe-agent#readme) - The 100-line AI agent that solves GitHub issues. Radically simple but scores >74% on SWE-bench verified. by [@SWE-agent](https://github.com/SWE-agent) (6,757 stars)
 - [**Reflexion**](https://github.com/noahshinn/reflexion#readme) - Language agents with verbal reinforcement learning. Agents that learn from mistakes through self-reflection. by [@noahshinn](https://github.com/noahshinn) (3,242 stars)
+- [**Autohand Code**](https://github.com/autohandai/code-cli#readme) - Self-evolving coding agent that runs in your terminal. by [@autohandai](https://github.com/autohandai) (181 stars)
 <!-- /AUTOGEN:coding -->
 
 ## Multi-Agent Frameworks
@@ -288,6 +292,7 @@ Projects connecting AI agents to physical devices, robotics, and real-world envi
 - [GAIA](https://huggingface.co/gaia-benchmark) (ICLR'23) - General AI assistant capabilities benchmark.
 - [EvoClaw](https://github.com/FSoft-AI4Code/EvoClaw) (arXiv'26) - Evaluating agents on continuous software evolution.
 - [LoCoMo](https://github.com/snap-research/locomo) (arXiv'25) - Long-context memory benchmark for agent memory systems.
+- [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) ([arXiv'26](https://arxiv.org/abs/2604.08523)) - Live-web evaluation with 281 total tasks (V1: 152; V2: 129), isolated execution, and replayable five-layer traces.
 - [ATM-Bench](https://github.com/JingbiaoMei/ATM-Bench) (arXiv'26) - First multimodal, multi-source benchmark for personalized referential memory QA over ~4 years of personal records (emails, images, videos).
 - [PerspectiveGap](https://github.com/WhymustIhaveaname/PerspectiveGap) (arXiv'26) - The first benchmark for multi-agent orchestration prompt writing, across 110 scenarios and 10 topologies.
 

--- a/data/projects.json
+++ b/data/projects.json
@@ -1471,5 +1471,57 @@
       "protocol"
     ],
     "stars": 553
+  },
+  {
+    "name": "agent-qa",
+    "repo": "vostride/agent-qa",
+    "description": "Self-improving QA agent for natural-language web and mobile tests, using persistent run memory to adapt to UI changes and catch regressions. Source-available under FSL-1.1-ALv2: use is permitted except to provide a competing commercial product or service, and each release converts to Apache-2.0 after two years.",
+    "category": "evolution",
+    "maintainer": "vostride",
+    "tags": [
+      "self-improving",
+      "memory",
+      "source-available"
+    ],
+    "stars": 896
+  },
+  {
+    "name": "OpenProgram",
+    "repo": "Fzkuji/OpenProgram",
+    "description": "Self-programming AI agent framework whose agents create, run, and refine their own workflows while the runtime manages models, tools, memory, context, and multi-agent collaboration.",
+    "category": "evolution",
+    "maintainer": "Fzkuji",
+    "tags": [
+      "self-programming",
+      "self-improving",
+      "open-source"
+    ],
+    "stars": 324
+  },
+  {
+    "name": "Orkas",
+    "repo": "Orkas-AI/Orkas",
+    "description": "Local-first multi-agent desktop application whose specialist agents improve through reflection and crystallize successful approaches into private reusable skills.",
+    "category": "evolution",
+    "maintainer": "Orkas-AI",
+    "tags": [
+      "self-evolving",
+      "multi-agent",
+      "skill-memory"
+    ],
+    "stars": 1545
+  },
+  {
+    "name": "Autohand Code",
+    "repo": "autohandai/code-cli",
+    "description": "Self-evolving coding agent that runs in your terminal.",
+    "category": "coding",
+    "maintainer": "autohandai",
+    "tags": [
+      "terminal",
+      "self-evolving",
+      "coding-agent"
+    ],
+    "stars": 181
   }
 ]


### PR DESCRIPTION
## Summary
- recover four previously reviewed contributions on top of current main
- refresh live metadata and preserve canonical repository/license wording
- regenerate the structured README entries

Recovered entries: agent-qa, OpenProgram, Orkas, and Autohand Code.

## Verification
- `node scripts/generate-readme.js`
- `node scripts/validate.js` — 117 projects, 10 categories, passed
- `git diff --check`

This is a maintainer-authored replacement for closed stale PRs #46, #44, #38, and #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)