### PR TITLE
Add SandBase Harness to platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Platforms and tools for building, deploying, and managing AI agents.
 - [**Agent-Squad**](https://github.com/2FastLabs/agent-squad#readme) - Flexible framework for managing multiple AI agents and handling complex conversations. by [@2FastLabs](https://github.com/2FastLabs) (7,752 stars)
 - [**PySpur**](https://github.com/PySpur-Dev/pyspur#readme) - Visual playground for agentic workflows with rapid iteration on multi-agent pipelines. by [@PySpur-Dev](https://github.com/PySpur-Dev) (5,779 stars)
 - [**MS-Agent**](https://github.com/modelscope/ms-agent#readme) - Lightweight framework by ModelScope to empower agentic execution of complex tasks with memory and deep research. by [@modelscope](https://github.com/modelscope) (4,374 stars)
+- [**SandBase Harness**](https://github.com/sandbaseai/sandbase-harness#readme) - Local-first, self-hosted AI agent runtime with sandboxed sessions, MCP tool governance, persistent memory, credentials, audit and replay, and a local Console. by [@sandbaseai](https://github.com/sandbaseai) (642 stars)
 <!-- /AUTOGEN:platforms -->
 
 ## Agent Coding and Software Engineering

--- a/data/projects.json
+++ b/data/projects.json
@@ -1536,5 +1536,18 @@
       "coding-agent"
     ],
     "stars": 181
+  },
+  {
+    "name": "SandBase Harness",
+    "repo": "sandbaseai/sandbase-harness",
+    "description": "Local-first, self-hosted AI agent runtime with sandboxed sessions, MCP tool governance, persistent memory, credentials, audit and replay, and a local Console.",
+    "category": "platforms",
+    "maintainer": "sandbaseai",
+    "tags": [
+      "local",
+      "mcp",
+      "open-source"
+    ],
+    "stars": 642
   }
 ]


### PR DESCRIPTION
Maintainer listing for [#53](https://github.com/EvoMap/awesome-agent-evolution/issues/53).

Adds [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) to `data/projects.json` under `platforms`, with `README.md` regenerated from the data file.

## Why platforms, not evolution or swarm
The submitter asked for Agent Development Platforms. The repo is a local-first self-hosted agent runtime (sessions, sandbox backends, MCP bridge, credentials, audit/replay, Console), not a self-evolution loop and not a swarm orchestrator. It is not listed in `awesome-agent-swarm`.

## Inclusion checks
- Canonical repo `sandbaseai/sandbase-harness` (not archived/disabled; `full_name` matches)
- Apache-2.0 `LICENSE`; TypeScript `src/` (`api`, `cli`, `core`, `mcp`, `sandbox`, …) and `tests/`
- Active: last push 2026-08-31; latest release `v0.3.8`
- Documented: README + `docs/installation.md`
- Traction: 642 stars (threshold 50)
- Description states mechanical capabilities only; isolation is backend-dependent and is not claimed as universal

## Checks run locally
- `node scripts/generate-readme.js` — idempotent; 119 projects / 10 categories
- `node scripts/validate.js` — `Validated 119 projects across 10 categories / Validation passed.`
- `node scripts/check-links.js` — `119 ok, 0 failures, 0 warnings` (includes the new repo)

Closes #53.