### PR TITLE
Fix SWE-Milestone paper listing (was incorrectly titled EvoClaw)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Projects connecting AI agents to physical devices, robotics, and real-world envi
 ### Self-Evolution and Lifelong Learning
 
 - [Live-SWE-agent: Can Software Engineering Agents Self-Evolve on the Fly?](https://arxiv.org/abs/2511.13646) (arXiv'25) - First live agent that autonomously evolves itself during runtime. 77.4% on SWE-bench Verified.
-- [EvoClaw: Evaluating AI Agents on Continuous Software Evolution](https://arxiv.org/abs/2603.13428) (arXiv'26) - Benchmark revealing performance drops from >80% to at most 38% in continuous evolution settings.
+- [SWE-Milestone: Evaluating AI Agents on Continuous Software Evolution](https://arxiv.org/abs/2603.13428) (ICML'26) - Benchmark revealing performance drops from >80% on isolated tasks to 38.03% in continuous evolution settings.
 - [Symbolic Learning Enables Self-Evolving Agents](https://arxiv.org/abs/2406.18532) (arXiv'24) - Agents that evolve through symbolic representation learning.
 - [Building Self-Evolving Agents via Experience-Driven Lifelong Learning](https://arxiv.org/abs/2504.01072) (arXiv'25) - Framework and benchmark for lifelong agent learning.
 - [Darwin Godel Machine](https://arxiv.org/abs/2505.22954) (arXiv'25) - Agents that rewrite their own code through evolutionary pressure.
@@ -292,7 +292,7 @@ Projects connecting AI agents to physical devices, robotics, and real-world envi
 - [WebArena](https://github.com/web-arena-x/webarena) (ICLR'24) - Realistic web environment for autonomous agents.
 - [OSWorld](https://github.com/xlang-ai/OSWorld) (NeurIPS'24) - Open-ended tasks in real computer environments.
 - [GAIA](https://huggingface.co/gaia-benchmark) (ICLR'23) - General AI assistant capabilities benchmark.
-- [EvoClaw](https://github.com/FSoft-AI4Code/EvoClaw) (arXiv'26) - Evaluating agents on continuous software evolution.
+- [SWE-Milestone](https://github.com/DeepCommit-ai/SWE-Milestone) (ICML'26) - Evaluating agents on continuous software evolution.
 - [LoCoMo](https://github.com/snap-research/locomo) (arXiv'25) - Long-context memory benchmark for agent memory systems.
 - [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) ([arXiv'26](https://arxiv.org/abs/2604.08523)) - Live-web evaluation with 281 total tasks (V1: 152; V2: 129), isolated execution, and replayable five-layer traces.
 - [ATM-Bench](https://github.com/JingbiaoMei/ATM-Bench) (arXiv'26) - First multimodal, multi-source benchmark for personalized referential memory QA over ~4 years of personal records (emails, images, videos).


### PR DESCRIPTION
## What does this PR do?

Correct the [arXiv 2603.13428](https://arxiv.org/abs/2603.13428) listing. The live paper title is **SWE-Milestone: Evaluating AI Agents on Continuous Software Evolution**, not EvoClaw. The previous GitHub URL `FSoft-AI4Code/EvoClaw` is a confirmed 404; this PR replaces it with the official benchmark repo published in the paper HTML.

Papers live in README (not `data/projects.json`). Only these two rows changed.

### Before

- Papers: `[EvoClaw: Evaluating AI Agents on Continuous Software Evolution](https://arxiv.org/abs/2603.13428) (arXiv'26) - Benchmark revealing performance drops from >80% to at most 38% in continuous evolution settings.`
- Benchmarks: `[EvoClaw](https://github.com/FSoft-AI4Code/EvoClaw) (arXiv'26) - Evaluating agents on continuous software evolution.`

### After

- Papers: `[SWE-Milestone: Evaluating AI Agents on Continuous Software Evolution](https://arxiv.org/abs/2603.13428) (ICML'26) - Benchmark revealing performance drops from >80% on isolated tasks to 38.03% in continuous evolution settings.`
- Benchmarks: `[SWE-Milestone](https://github.com/DeepCommit-ai/SWE-Milestone) (ICML'26) - Evaluating agents on continuous software evolution.`

### Evidence (checked live, not inferred)

- arXiv abs title: SWE-Milestone. Comments: `ICML 2026`. Abstract: scores drop from `>80%` on isolated tasks to `38.03%` in continuous settings. No EvoClaw name and no code URL on the abs page.
- Paper HTML (v4) publishes official links: Benchmark `github.com/DeepCommit-ai/SWE-Milestone`, pipeline `github.com/DeepCommit-ai/DeepCommit`.
- `gh api repos/FSoft-AI4Code/EvoClaw` → HTTP 404. `gh api repos/DeepCommit-ai/SWE-Milestone` → public MIT repo, description `[ICML 2026] Evaluating AI Agents on Continuous Software Evolution`, homepage `https://swe-milestone.com`. `EvoClaw-Bench/EvoClaw` 301-redirects to that same repo (rename), and was not substituted as the listed URL.
- Unrelated GitHub hits (`slhleosun/EvoClaw`, `clawinfra/evoclaw`, etc.) were not used.

## Checklist

- [x] Project added to `data/projects.json` with correct schema — N/A: paper/benchmark rows are hand-maintained in README
- [x] `node scripts/generate-readme.js` was run and README.md is up to date (idempotent; AUTOGEN sections unchanged)
- [x] `node scripts/validate.js` passes (`Validated 119 projects across 10 categories` / `Validation passed.`)
- [x] Project meets inclusion criteria (open source, active, documented, 50+ stars or a documented novelty exception) — N/A for paper-row correction; official code repo is public MIT
- [x] Category and cross-list scope are correct; any duplicate listing is justified
- [x] Description is concise, objective, starts with a capital letter, and ends with punctuation
- [x] Links, paper, license, and factual claims were checked against primary sources
- [x] No duplicate entries
- [x] `git diff --check` is clean
- [x] `node scripts/check-links.js` not applicable (script only checks `data/projects.json`, which this PR does not change)

## Category

- [x] Research Paper

🤖 Generated with [Claude Code](https://claude.com/claude-code)