### PR TITLE
Add AgentDescent to Agent Evolution and Self-Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Projects focused on enabling AI agents to evolve, learn, and improve autonomousl
 - [**OpenProgram**](https://github.com/Fzkuji/OpenProgram#readme) - Self-programming AI agent framework whose agents create, run, and refine their own workflows while the runtime manages models, tools, memory, context, and multi-agent collaboration. by [@Fzkuji](https://github.com/Fzkuji) (350 stars)
 - [**Reef**](https://github.com/Human-Agent-Society/reef#readme) - Continual learning infra for self-improving agents. Serves agent traffic, turns matched feedback into model-weight or harness updates, and publishes accepted updates as versioned artifacts. by [@Human-Agent-Society](https://github.com/Human-Agent-Society) (343 stars)
 - [**SEAgent**](https://github.com/SunzeY/SEAgent#readme) - Self-Evolving Computer Use Agent with Autonomous Learning from Experience. by [@SunzeY](https://github.com/SunzeY) (263 stars)
+- [**AgentDescent**](https://github.com/Birfy/agentdescent#readme) - Parallel, asynchronous optimizer for self-evolving agents: workers propose diffs to a shared library of skills, prompts and harnesses, and an aggregator resolves conflicts and accepts merges on a Beta posterior over held-out reward. by [@Birfy](https://github.com/Birfy) (203 stars)
 <!-- /AUTOGEN:evolution -->
 
 ## Memory Systems

--- a/data/projects.json
+++ b/data/projects.json
@@ -1525,6 +1525,19 @@
     "stars": 343
   },
   {
+    "name": "AgentDescent",
+    "repo": "Birfy/agentdescent",
+    "description": "Parallel, asynchronous optimizer for self-evolving agents: workers propose diffs to a shared library of skills, prompts and harnesses, and an aggregator resolves conflicts and accepts merges on a Beta posterior over held-out reward.",
+    "category": "evolution",
+    "maintainer": "Birfy",
+    "tags": [
+      "self-evolving",
+      "self-improving",
+      "research"
+    ],
+    "stars": 203
+  },
+  {
     "name": "Autohand Code",
     "repo": "autohandai/code-cli",
     "description": "Self-evolving coding agent that runs in your terminal.",


### PR DESCRIPTION
## Project

[**AgentDescent**](https://github.com/Birfy/agentdescent) — a parallel, asynchronous optimizer for self-evolving agents.

## Why it belongs in this list

The list's `evolution` category collects systems where the agent itself is what improves. AgentDescent is the optimizer for that loop, and its specific contribution is **parallelism**: serial self-improvement is bounded at one accepted change per iteration, so AgentDescent runs *N* workers proposing diffs concurrently against a shared, version-controlled artifact library (skills, prompts, harness modules, verifiers) and makes the aggregator the thing that resolves the resulting conflicts.

Concretely, the merge step is: staleness filter → conflict resolution → fusion tournament → Beta-posterior acceptance over held-out reward → transactional commit. Changes are gated by blast radius — skills merge freely, harnesses and verifiers are forced through an oracle, safety and permission layers are frozen. A barrier-free asynchronous runtime lets rounds overlap under a lag budget.

It is complementary to the evolutionary-search entries already listed (OpenEvolve, A-Evolve): those search a solution space, this one aggregates concurrent proposals into an artifact library.

## Checklist against CONTRIBUTING

- **Relevant** — agent self-evolution; `evolution` category
- **Active** — commits within the last week
- **Open source** — MIT
- **Documented** — README plus MkDocs site at https://birfy.github.io/agentdescent/, and 19 runnable algorithm ports as examples
- **Traction** — 203 stars, published on PyPI as `agentdescent`

## Changes

- Added the entry to `data/projects.json` (`category: evolution`)
- Ran `node scripts/generate-readme.js`
- `node scripts/validate.js` → passed (120 projects, 10 categories)
- `node scripts/check-links.js` → 120 ok, 0 failures, 0 warnings

Disclosure: I maintain this project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)